### PR TITLE
Eliminate old categories, traits, and polymorphic executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,13 +421,11 @@ namespace execution {
   // Executor type traits:
 
   template<class T> struct is_one_way_executor;
-  template<class T> struct is_host_based_one_way_executor;
   template<class T> struct is_non_blocking_one_way_executor;
   template<class T> struct is_two_way_executor;
   template<class T> struct is_bulk_two_way_executor;
 
   template<class T> constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
-  template<class T> constexpr bool is_host_based_one_way_executor_v = is_host_based_one_way_executor<T>::value;
   template<class T> constexpr bool is_non_blocking_one_way_executor_v = is_non_blocking_one_way_executor<T>::value;
   template<class T> constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
   template<class T> constexpr bool is_bulk_two_way_executor_v = is_bulk_two_way_executor<T>::value;
@@ -498,10 +496,8 @@ namespace execution {
   // Polymorphic executor wrappers:
 
   class one_way_executor;
-  class host_based_one_way_executor;
   class non_blocking_one_way_executor;
   class two_way_executor;
-  class non_blocking_two_way_executor;
 
 } // namespace execution
 } // inline namespace concurrency_v2
@@ -1176,7 +1172,6 @@ In the Table below,
 ### Determining that an executor satisfies the executor requirements
 
     template<class T> struct is_one_way_executor;
-    template<class T> struct is_host_based_one_way_executor;
     template<class T> struct is_non_blocking_one_way_executor;
     template<class T> struct is_two_way_executor;
     template<class T> struct is_bulk_two_way_executor;
@@ -1186,7 +1181,6 @@ This sub-clause contains templates that may be used to query the properties of a
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
 | `template<class T>` <br/>`struct is_one_way_executor` | `T` meets the syntactic requirements for `OneWayExecutor`. | `T` is a complete type. |
-| `template<class T>` <br/>`struct is_host_based_one_way_executor` | `T` meets the syntactic requirements for `HostBasedOneWayExecutor`. | `T` is a complete type. |
 | `template<class T>` <br/>`struct is_non_blocking_one_way_executor` | `T` meets the syntactic requirements for `NonBlockingOneWayExecutor`. | `T` is a complete type. |
 | `template<class T>` <br/>`struct is_two_way_executor` | `T` meets the syntactic requirements for `TwoWayExecutor`. | `T` is a complete type. |
 | `template<class T>` <br/>`struct is_bulk_two_way_executor` | `T` meets the syntactic requirements for `BulkTwoWayExecutor`. | `T` is a complete type. |
@@ -1760,31 +1754,6 @@ Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(s
 
 *Effects:* Performs `e.execute(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
 
-### Class `host_based_one_way_executor`
-
-Class `host_based_one_way_executor` satisfies the general requirements on polymorphic executor wrappers, with the additional definitions below.
-
-```
-class host_based_one_way_executor
-{
-public:
-  // execution agent creation
-  template<class Function, class ProtoAllocator = std::allocator<void>>
-    void execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
-};
-```
-
-Class `host_based_one_way_executor` satisfies the `HostBasedOneWayExecutor` requirements. The target object shall satisfy the `HostBasedOneWayExecutor` requirements.
-
-```
-template<class Function, class ProtoAllocator>
-  void execute(Function&& f, const ProtoAllocator& a) const;
-```
-
-Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
-
-*Effects:* Performs `e.execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
-
 ### Class `non_blocking_one_way_executor`
 
 Class `non_blocking_one_way_executor` satisfies the general requirements on polymorphic executor wrappers, with the additional definitions below.
@@ -1875,80 +1844,6 @@ Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(s
 *Effects:* Performs `e.async_execute(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
 
 *Returns:* A future with an associated shared state that will contain the result of `fd()`. [*Note:* `e.async_execute(g)` may return any future type that satisfies the Future requirements, and not necessarily `std::future`. One possible implementation approach is for the polymorphic wrapper to attach a continuation to the inner future via that object's `then()` member function. When invoked, this continuation stores the result in the outer future's associated shared and makes that shared state ready. *--end note*]
-
-### Class `non_blocking_two_way_executor`
-
-Class `non_blocking_two_way_executor` satisfies the general requirements on polymorphic executor wrappers, with the additional definitions below.
-
-```
-class non_blocking_two_way_executor
-{
-public:
-  // execution agent creation
-  template<class Function>
-    result_of_t<decay_t<Function>()>
-      sync_execute(Function&& f) const;
-  template<class Function>
-    std::future<result_of_t<decay_t<Function>()>>
-      async_execute(Function&& f) const;
-  template<class Function>
-    std::future<result_of_t<decay_t<Function>()>>
-      async_post(Function&& f) const;
-  template<class Function>
-    std::future<result_of_t<decay_t<Function>()>>
-      async_defer(Function&& f) const;
-};
-```
-
-Class `non_blocking_two_way_executor` satisfies the `NonBlockingTwoWayExecutor` requirements. The target object shall satisfy the `NonBlockingTwoWayExecutor` requirements.
-
-```
-template<class Executor, class Function>
-  result_of_t<decay_t<Function>()>
-    sync_execute(Function&& f);
-```
-
-Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
-
-*Effects:* Performs `e.execute(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
-
-*Returns:* The return value of `fd()`.
-
-```
-template<class Function>
-  std::future<result_of_t<decay_t<Function>()>>
-    async_execute(Function&& f) const;
-```
-
-Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
-
-*Effects:* Performs `e.async_execute(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
-
-*Returns:* A future with an associated shared state that will contain the result of `fd()`.
-
-```
-template<class Function>
-  std::future<result_of_t<decay_t<Function>()>>
-    async_post(Function&& f) const;
-```
-
-Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
-
-*Effects:* Performs `e.async_post(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
-
-*Returns:* A future with an associated shared state that will contain the result of `fd()`.
-
-```
-template<class Function>
-  std::future<result_of_t<decay_t<Function>()>>
-    async_defer(Function&& f) const;
-```
-
-Let `e` be the target object of `*this`. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
-
-*Effects:* Performs `e.async_defer(g)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`.
-
-*Returns:* A future with an associated shared state that will contain the result of `fd()`.
 
 ## Thread pool type
 


### PR DESCRIPTION
These changes eliminate some old functionality that is obsoleted by our smaller categorization