### PR TITLE
Address simple TODO items

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ The directionality property of an execution function may be one of the following
 
 * *One-way:* The execution function creates execution agents without a channel for awaiting the completion of a submitted function object or for obtaining its result. *Note:* That is, the executor provides fire-and-forget semantics. *--end note*] The names of execution functions having one-way directionality do not have an associated prefix.
 * *Synchronous two-way:* The execution function blocks until execution of the submitted function is complete, and returns the result. The names of execution functions having synchronous two-way directionality have the prefix `sync_`.
-* *Asynchronous two-way:* The execution function provides a *TODO* future-like channel for awaiting the completion of a submitted function object and obtaining its result. The names of execution functions having asynchronous two-way directionality have the prefix `async_` or `then_`.
+* *Asynchronous two-way:* The execution function returns a `Future` for awaiting the completion of a submitted function object and obtaining its result. The names of execution functions having asynchronous two-way directionality have the prefix `async_` or `then_`.
 
 ##### Requirements on execution functions of one-way directionality
 

--- a/README.md
+++ b/README.md
@@ -2262,11 +2262,10 @@ async(const Executor& exec, Function&& f, Args&&... args);
 
 *Returns:* Equivalent to:
 
-`return execution::async_post(exec, [=]{ return INVOKE(f, args...); });`
+    auto __g = bind(std::forward<Function>(f), std::forward<Args>(args)...);
+    return execution::async_post(exec, [__g = move(__g)]{ return INVOKE(__g); });
 
-XXX This forwarding doesn't look correct to me
-
-#### `std::future::then()`
+#### `std::experimental::future::then()`
 
 The member function template `then` provides a mechanism for attaching a *continuation* to a `std::future` object,
 which will be executed on a new execution agent created by an executor.
@@ -2290,7 +2289,7 @@ specify that `.then()` submits the continuation using `exec.post()` if the
 future is already ready at the time when `.then()` is called, and to submit
 using `exec.execute()` otherwise.
 
-#### `std::shared_future::then()`
+#### `std::experimental::shared_future::then()`
 
 The member function template `then` provides a mechanism for attaching a *continuation* to a `std::shared_future` object,
 which will be executed on a new execution agent created by an executor.


### PR DESCRIPTION
I went through the paper looking for TODOs and XXXs that I thought I could fix simply.

One significant TODO item is a concrete specification of `std::experimental::future::then()` and `std::experimental::shared_future::then()`. I suggest we don't attempt to address those in R1 and tackle them in R2.

There are a few remaining TODOs that look like they might be simple, but it wasn't immediately clear to me how to address them.