### PR TITLE
Clarify that customization points never weaken an executor's semantic guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,18 @@ Because we envision executors to be the workhorses of execution in generic
 code, it is critical that they be adaptable to a variety of use cases. For
 example, a generic function like `std::invoke()` should be interoperable with
 as many types of executor as possible, not just that set of executors which
-natively provide the synchronous, single-agent execution function `sync_execute()`. To
-generalize across use cases, we have designed executor customization points to
-adapt the behavior of an executor when its native behavior is not a precise
-match for the use case of interest. For example, `std::invoke()` may
-interoperate with an executor which natively provides the execution function
-`async_execute()` by calling the customization point `execute::sync_execute()`.
-This customization point will adapt the executor by calling its natively
-provided `async_execute()` execution function, and wait on the resulting future. In this
-way, generic code may uniformly compose with executors with minimal
-restriction.
+natively provide the synchronous, single-agent execution function
+`sync_execute()`. To generalize across use cases, we have designed executor
+customization points to adapt the behavior of an executor when its native
+behavior is not a precise match for the use case of interest. These adaptations
+performed by executor customization points are always performed in such a way
+as to ensure that various semantic guarantees provided by executors are never
+weakened. For example, `std::invoke()` may interoperate with an executor which
+natively provides the execution function `async_execute()` by calling the
+customization point `execute::sync_execute()`. This customization point will
+adapt the executor by calling its natively provided `async_execute()` execution
+function, and wait on the resulting future. In this way, generic code may
+uniformly compose with executors with minimal restriction.
 
 Our design focuses on defining a set of optional execution functions instead of
 imposing a set of strict executor requirements to maximize the latitude of


### PR DESCRIPTION
Prompted by ChrisM's recent question by email