### PR TITLE
Reword static_thread_pool::attach.

### DIFF
--- a/wording.md
+++ b/wording.md
@@ -1742,10 +1742,10 @@ void attach();
 *Effects:* Adds the calling thread to the pool such that this thread is used to
 execute submitted function objects. (Note: Threads created during thread pool
 construction, or previously attached to the pool, will continue to be used for
-function object execution.) Blocks the calling thread until signalled to
-complete by `stop()` or `wait()`, and then blocks until all the threads created
-during `static_thread_pool` object construction have completed. (NAMING: a
-possible alternate name for this function is `join()`.)
+function object execution. --end note) Blocks the calling thread until
+signalled to complete by `stop()` or `wait()`, and then blocks until all the
+threads created during `static_thread_pool` object construction have completed.
+(NAMING: a possible alternate name for this function is `join()`.)
 
 ```
 void stop();

--- a/wording.md
+++ b/wording.md
@@ -1739,14 +1739,13 @@ followed by `wait()`.
 void attach();
 ```
 
-*Effects:* adds the calling thread to the pool of workers. Blocks the calling
-thread until signalled to complete by `stop()` or `wait()`, and then blocks
-until all the threads created during `static_thread_pool` object construction have
-completed. (Note: The implementation is required to use
-the attached thread to execute submitted function objects. RATIONALE:
-implementations in terms of the Windows thread pool cannot utilise
-user-provided threads. --end note) (NAMING: a possible alternate name for this
-function is `join()`.)
+*Effects:* Adds the calling thread to the pool such that this thread is used to
+execute submitted function objects. (Note: Threads created during thread pool
+construction, or previously attached to the pool, will continue to be used for
+function object execution.) Blocks the calling thread until signalled to
+complete by `stop()` or `wait()`, and then blocks until all the threads created
+during `static_thread_pool` object construction have completed. (NAMING: a
+possible alternate name for this function is `join()`.)
 
 ```
 void stop();


### PR DESCRIPTION
- Put requirement that thread will be used for execution up front.

- Remove Windows rationale that is not relevant to a static thread pool (it
  was carried over from when the class still had dynamic thread pool
  capabilities.)