### PR TITLE
Change the names of these types related to blocking:

### DIFF
--- a/explanatory.md
+++ b/explanatory.md
@@ -285,10 +285,10 @@ scheduled for invocation using the executor's `post` customization point:
         }
       );
 
-A non-blocking execution function is used above to ensure that operations that
+A never-blocking execution function is used above to ensure that operations that
 always complete immediately do not lead to deadlock or stack exhaustion. On the
 other hand, if the operation completes later then the asynchronous operation
-invokes the completion handler using the potentially-blocking execution
+invokes the completion handler using the possibly-blocking execution
 function:
 
     std::execution::execute(ex,
@@ -781,7 +781,7 @@ requested interaction's requirements.
 
 [^adaptation_caveat]: In certain cases, some interactions are impossible
 because their requirements are inherently incompatible with a particular
-executor's provided functionality. For example, a requirement for non-blocking
+executor's provided functionality. For example, a requirement for never-blocking
 execution from an executor which always executes "inline".
 
 As a simple example, consider the adaptation performed by
@@ -824,7 +824,7 @@ behavior when adapting an executor's native functionality. During adaptation,
          unless the executor itself introduces those threads as an effect of
          creating execution agents. Additionally, this rule implies that a
          customization point never weakens guarantees made by an executor. For
-         example, given a non-blocking executor, a customization point
+         example, given a never-blocking executor, a customization point
          never[^invariant_caveat] blocks its client's execution.  Moreover, a
          customization point never weakens the group execution ordering
          guarantee provided by a bulk executor.
@@ -987,19 +987,19 @@ The default value of `executor_execution_mapping_category` is `thread_execution_
 
 **Blocking guarantee.** When a client uses an executor to create execution
 agents, the execution of that client may be blocked pending the completion of
-those execution agents. The `executor_execute_blocking_category` trait
+those execution agents. The `executor_execute_blocking_guarantee` trait
 describes the way in which these agents are guaranteed to block their client.
 
 When executors create execution agents, those agents
 possibly block the client's execution pending the completion of those agents.
-This guarantee is given by `executor_execute_blocking_category`, which
+This guarantee is given by `executor_execute_blocking_guarantee`, which
 returns one of three values:
 
-  1. `blocking_execution_tag`: The agents' execution blocks the client.
-  2. `possibly_blocking_execution_tag`: The agent's execution possibly block the client.
-  3. `non_blocking_execution_tag`: The agent's execution does not block the client.
+  1. `always_blocking_execution`: The agents' execution blocks the client.
+  2. `possibly_blocking_execution`: The agents' execution possibly blocks the client.
+  3. `never_blocking_execution`: The agents' execution does not block the client.
 
-The guarantee provided by `executor_execute_blocking_category` only applies to
+The guarantee provided by `executor_execute_blocking_guarantee` only applies to
 those customization points whose name is suffixed with `execute`. Exceptions
 are the `sync_` customization points, which must always block their client by
 definition. When the agents created by an executor possibly block its client,
@@ -1007,7 +1007,7 @@ definition. When the agents created by an executor possibly block its client,
   for querying its actual blocking behavior. However, our design prescribes no
   interface for doing so.
 
-The default value of `executor_execute_blocking_category` is `possibly_blocking_execution_tag`.
+The default value of `executor_execute_blocking_guarantee` is `possibly_blocking_execution`.
 
 **Bulk forward progress guarantee.** When an executor creates a group of execution
 agents, their forward progress obeys certain semantics. For example, a group of
@@ -1115,7 +1115,7 @@ can be used to wait for execution to complete containing the result of
 `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
 `bulk_then_execute` may or may not the caller until execution completes,
-depending on the value of `executor_execute_blocking_category_t<Executor>`.
+depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 `bulk_then_execute` is the most general execution function we have identified
 because it may be used to implement any other execution function without having
@@ -1163,7 +1163,7 @@ created execution agent calls `std::forward<Function>(func)(i, r, s)`, where
 `i` is of type `executor_index_t<Executor>`, `r` is a function object returned
 from `return_factory` and `s` is a shared object returned from `shared_factory`.
 `bulk_async_execute` may or may not the caller until execution completes,
-depending on the value of `executor_execute_blocking_category_t<Executor>`.
+depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 Like `bulk_then_execute`, `bulk_async_execute`
 returns a future corresponding to the result of the asynchronous group of
@@ -1208,7 +1208,7 @@ created execution agent calls `std::forward<Function>(func)(i, r, s)`, where `i`
 is of type `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
 `bulk_async_post` may or may not the caller until execution completes, depending
-on the value of `executor_execute_blocking_category_t<Executor>`.
+on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 `bulk_async_post` is equivalent to `bulk_async_execute` except that it makes an
 additional guarantee not to block the client's execution. Some executors will
@@ -1216,7 +1216,7 @@ not be able to provide such a guarantee and could not be adapted to this
 functionality when `bulk_async_post` is absent. For example, an implementation
 of `bulk_async_post` which simply forwards its arguments directly to
 `bulk_async_execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is `nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
 ### `bulk_async_defer`
 
@@ -1237,7 +1237,7 @@ created execution agent calls `std::forward<Function>(func)(i, r, s)`, where `i`
 is of type `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
 `bulk_async_defer` may or may not the caller until execution completes,
-depending on the value of `executor_execute_blocking_category_t<Executor>`.
+depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 `bulk_async_defer` is equivalent to `bulk_async_execute` except that it makes an
 additional guarantee not to block the client's execution. Some executors will
@@ -1245,7 +1245,7 @@ not be able to provide such a guarantee and could not be adapted to this
 functionality when `bulk_async_defer` is absent. For example, an implementation
 of `bulk_async_defer` which simply forwards its arguments directly to
 `bulk_async_execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is `nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
 **Comparison to bulk_async_post.** The behavior of `bulk_async_defer` is
 semantically equivalent to `bulk_async_post` and is primarily to indicate an
@@ -1271,7 +1271,7 @@ whose execution may begin immediately and returns the result of
 `executor_index_t<Executor>`, `r` is a function object retured from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
 `bulk_sync_execute` may or may not the caller until execution completes,
-depending on the value of `executor_execute_blocking_category_t<Executor>`.
+depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 `bulk_sync_execute` is equivalent to `bulk_async_execute` except that it blocks
 its client until the result of execution is complete. It returns this result
@@ -1335,7 +1335,7 @@ returns a future that can be used to wait for execution to complete containing
 the result of `func`. The created execution agent calls
 `std::forward<Function>(func)()`. `then_execute` may or may not the caller until
 execution completes, depending on the value of
-`executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
+`executor_execute_blocking_guarantee_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
 `then_execute` creates an asynchronous execution agent. It may be implemented
@@ -1388,7 +1388,7 @@ executor `exec` whose execution may begin immediately and returns a future that
 can be used to wait for execution to complete containing the result of `func`.
 The created execution agent calls `std::forward<Function>(func)()`.
 `async_execute` may or may not the caller until execution completes, depending
-on the value of `executor_execute_blocking_category_t<Executor>`. The allocator
+on the value of `executor_execute_blocking_guarantee_t<Executor>`. The allocator
 `alloc` can be used to allocate memory for `func`.
 
 `async_execute`  may be implemented by using `then_execute` with a ready `void` future:
@@ -1440,8 +1440,8 @@ additional guarantee not to block the client's execution. Some executors will
 not be able to provide such a guarantee and could not be adapted to this
 functionality when `async_post` is absent. For example, an implementation of
 `async_post` which simply forwards its arguments directly to `async_post` is
-possible only if `executor_execute_blocking_category_t<Executor>` is
-`nonblocking_execution_tag`.
+possible only if `executor_execute_blocking_guarantee_t<Executor>` is
+`never_blocking_execution`.
 
 ### `async_defer`
 
@@ -1463,8 +1463,8 @@ additional guarantee not to block the client's execution. Some executors will
 not be able to provide such a guarantee and could not be adapted to this
 functionality when `async_defer` is absent. For example, an implementation of
 `async_defer` which simply forwards its arguments directly to `async_defer` is
-possible only if `executor_execute_blocking_category_t<Executor>` is
-`nonblocking_execution_tag`.
+possible only if `executor_execute_blocking_guarantee_t<Executor>` is
+`never_blocking_execution`.
 
 **Comparison to async_post.** `async_defer`'s semantics are identical to
 `async_post`. That is, they may be used interchangeably without effecting a
@@ -1553,8 +1553,8 @@ guarantee not to block the client's execution. Some executors will not be able
 to provide such a guarantee and could not be adapted to this functionality when
 `bulk_post` is absent. For example, an implementation of `bulk_post` which
 simply forwards its arguments directly to `bulk_execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is
-`nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is
+`never_blocking_execution`.
 
 ### `bulk_defer`
 
@@ -1577,8 +1577,8 @@ guarantee not to block the client's execution. Some executors will not be able
 to provide such a guarantee and could not be adapted to this functionality when
 `bulk_defer` is absent. For example, an implementation of `bulk_defer` which
 simply forwards its arguments directly to `bulk_execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is
-`nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is
+`never_blocking_execution`.
 
 **Comparison to bulk_post.** `bulk_defer`'s semantics are identical to
 `bulk_post`. That is, they may be used interchangeably without effecting a
@@ -1601,7 +1601,7 @@ execution agent calls `std::forward<Function>(func)(i, s)`, where `i` is of type
 `executor_index_t<Executor>` and `s` is a shared object returned from
 `shared_factory`. `bulk_execute` may or may not the caller until execution
 completes, depending on the value of
-`executor_execute_blocking_category_t<Executor>`.
+`executor_execute_blocking_guarantee_t<Executor>`.
 
 `bulk_execute` is equivalent to `execute` except that it creates a single
 execution agent rather than a group of execution agents.
@@ -1646,7 +1646,7 @@ not to block the client's execution. Some executors will not be able to provide
 such a guarantee and could not be adapted to this functionality when `post` is
 absent. For example, an implementation of `post` which simply forwards its
 arguments directly to `execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is `nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
 ### `defer`
 
@@ -1664,7 +1664,7 @@ not to block the client's execution. Some executors will not be able to provide
 such a guarantee and could not be adapted to this functionality when `defer` is
 absent. For example, an implementation of `defer` which simply forwards its
 arguments directly to `execute` is possible only if
-`executor_execute_blocking_category_t<Executor>` is `nonblocking_execution_tag`.
+`executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
 **Comparison to post.** `defer`'s semantics are identical to `post`. That is,
 they may be used interchangeably without effecting a program's correctness.
@@ -1681,7 +1681,7 @@ implementation.
 `exec` whose execution may begin immediately and does not return a value. The
 created execution agent calls `std::forward<Function>(func)()`. `execute` may or
 may not the caller until execution completes, depending on the value of
-`executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
+`executor_execute_blocking_guarantee_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
 `execute` is equivalent to `bulk_execute` except that it creates a group of
@@ -1778,15 +1778,14 @@ make such guarantees. Incorporating a model of *boost blocking* into our design
 could be one option.
 
 ### Blocking Guarantees
->>>>>>> 8ad6f05dc1be48db0e8f30cc8211ae615f8cef0a
 
-The blocking property is not
+The blocking guarantee is not
   applied uniformly. It is both a holistic property of the executor type and
   also a property of individual customization points in a few exceptional
   cases. This design is currently controversial. The reason that we chose for
   blocking to be a property of the executor type was to avoid the combinatorial
-  explosion of three versions of each customization point: blocking,
-  non-blocking, and possibly blocking. An alternative design could avoid
+  explosion of three versions of each customization point: always-blocking,
+  never-blocking, and possibly-blocking. An alternative design could avoid
   explosively versioning customization points but would also require a way to
   introspect the blocking guarantee of individual customization points. A
   design which discarded the ability to introspect blocking guarantees is
@@ -1799,8 +1798,8 @@ granularity of individual customization points. The two-way `sync_` functions
 are exceptions because it is impossible to return the result of execution in a
 way that does not block the client which created that execution. The `post` and
 `defer` functions are exceptions to the executor's blocking trait because we
-desire the ability for a single executor to provide a blocking or
-possibly-blocking `execute` as well as the unconditionally non-blocking
+desire the ability for a single executor to provide an always-blocking or
+possibly-blocking `execute` as well as the unconditionally never-blocking
 customization points `post` and `defer`. In such a situation, all three of
 these customization points have different semantics.
 

--- a/wording.md
+++ b/wording.md
@@ -212,12 +212,12 @@ namespace execution {
   // Executor type traits:
 
   template<class T> struct is_one_way_executor;
-  template<class T> struct is_non_blocking_one_way_executor;
+  template<class T> struct is_never_blocking_one_way_executor;
   template<class T> struct is_two_way_executor;
   template<class T> struct is_bulk_two_way_executor;
 
   template<class T> constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
-  template<class T> constexpr bool is_non_blocking_one_way_executor_v = is_non_blocking_one_way_executor<T>::value;
+  template<class T> constexpr bool is_never_blocking_one_way_executor_v = is_never_blocking_one_way_executor<T>::value;
   template<class T> constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
   template<class T> constexpr bool is_bulk_two_way_executor_v = is_bulk_two_way_executor<T>::value;
 
@@ -240,14 +240,14 @@ namespace execution {
   template<class Executor>
     using executor_execution_mapping_category_t = typename executor_execution_mapping_catetory<Executor>::type;
 
-  struct blocking_execution_tag {};
-  struct possibly_blocking_execution_tag {};
-  struct non_blocking_execution_tag {};
+  struct always_blocking_execution {};
+  struct possibly_blocking_execution {};
+  struct never_blocking_execution {};
 
-  template<class Executor> struct executor_execute_blocking_category;
+  template<class Executor> struct executor_execute_blocking_guarantee;
 
   template<class Executor>
-    using executor_execute_blocking_category_t = typename executor_execute_blocking_category<Executor>::type;
+    using executor_execute_blocking_guarantee_t = typename executor_execute_blocking_guarantee<Executor>::type;
 
   // Bulk executor traits:
 
@@ -278,7 +278,7 @@ namespace execution {
   // Polymorphic executor wrappers:
 
   class one_way_executor;
-  class non_blocking_one_way_executor;
+  class never_blocking_one_way_executor;
   class two_way_executor;
 
 } // namespace execution
@@ -351,10 +351,10 @@ The parameters of the execution function and semantics that apply to the the exe
 
 The blocking semantics of an execution function may be one of the following:
 
-* *Potentially blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having potentially blocking semantics are named `execute`.
-* *Non-blocking:* The execution function shall not block the caller pending completion of the submitted function objects. Execution functions having non-blocking semantics are named `post` or `defer`.
+* *Possibly-blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having possibly-blocking semantics are named `execute`.
+* *Never-blocking:* The execution function shall not block the caller pending completion of the submitted function objects. Execution functions having never-blocking semantics are named `post` or `defer`.
 
-##### Requirements on execution functions having potentially blocking semantics
+##### Requirements on execution functions having possibly-blocking semantics
 
 In the Table below, `x` denotes a (possibly const) executor object of type `X` and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
 
@@ -362,14 +362,14 @@ In the Table below, `x` denotes a (possibly const) executor object of type `X` a
 |------------|-------------|---------------------- |
 | `x.execute(f, ...)` <br/> `execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `execute`. <br/> <br/> May block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
 
-##### Requirements on execution functions having non-blocking semantics
+##### Requirements on execution functions having never-blocking semantics
 
 In the Table below, `x` denotes a (possibly const) executor object of type `X` and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.post(f, ...)` <br/>`post(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `post`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
-| `x.defer(f, ...)` <br/>`defer(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `defer`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+| `x.post(f, ...)` <br/>`post(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `post`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `post` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+| `x.defer(f, ...)` <br/>`defer(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `defer`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `defer` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
 
 #### Directionality
 
@@ -445,18 +445,18 @@ The table below describes the execution member functions and non-member function
 
 | Cardinality | Directionality | Blocking semantics | Member function | Free function |
 | ------------ | -------------- | --------------------- | ------------------- | ---------------------- |
-| Single | One-way | Potentially blocking | `x.execute(f)` <br/> `x.execute(f, a)` | `execute(x, f)` <br/> `execute(x, f, a)` |
-| Single | One-way | Non-blocking | `x.post(f)` <br/> `x.post(f, a)` <br/> `x.defer(f)`  <br/> `x.defer(f, a)` | `post(x, f)` <br/> `post(x, f, a)` <br/> `defer(x, f)`  <br/> `defer(x, f, a)` |
-| Single | Two-way synchronous | Potentially blocking | `x.sync_execute(f)` <br/> `x.sync_execute(f, a)` | `sync_execute(x, f)` <br/> `sync_execute(x, f, a)` |
-| Single | Two-way synchronous | Non-blocking | NA | NA |
-| Single | Two-way asynchronous | Potentially blocking | `x.async_execute(f)` <br/> `x.async_execute(f, a)`  <br/> `x.then_execute(f, pred)` <br/> `x.then_execute(f, pred, a)` | `async_execute(x, f)` <br/> `async_execute(x, f, a)`  <br/> `then_execute(x, f, pred)` <br/> `then_execute(x, f, pred, a)` |
-| Single | Two-way asynchronous | Non-blocking | `x.async_post(f)` <br/> `x.async_post(f, a)` <br/> `x.async_defer(f)` <br/> `x.async_defer(f, a)` | `async_post(x, f)` <br/> `x.async_post(x, f, a)` <br/> `async_defer(x, f)` <br/> `x.async_defer(x, f, a)` |
-| Bulk | One-way | Potentially blocking | `x.bulk_execute(f, n, sf)` | `bulk_execute(x, f, n, sf)` |
-| Bulk | One-way | Non-blocking | `x.bulk_post(f, n, sf)` <br/> `x.bulk_defer(f, n, sf)` | `bulk_post(x, f, n, sf)` <br/> `bulk_defer(x, f, n, sf)` |
-| Bulk | Two-way synchronous | Potentially blocking | `x.bulk_sync_execute(f, n, rf, sf)` | `bulk_sync_execute(x, f, n, rf, sf)` |
-| Bulk | Two-way synchronous | Non-blocking | NA | NA |
-| Bulk | Two-way asynchronous | Potentially blocking | `x.bulk_async_execute(f, n, rf, sf)` <br/> `x.bulk_then_execute(f, n, pred, rf, sf)` | `bulk_async_execute(x, f, n, rf, sf)` <br/> `bulk_then_execute(x, f, n, pred, rf, sf)` |
-| Bulk | Two-way asynchronous | Non-blocking |  `x.bulk_async_post(f, n, rf, sf)` <br/> `x.bulk_async_defer(f, n, rf, sf)` | `bulk_async_post(x, f, n, rf, sf)` <br/> `bulk_async_defer(x, f, n, rf, sf)` |
+| Single | One-way | Possibly-blocking | `x.execute(f)` <br/> `x.execute(f, a)` | `execute(x, f)` <br/> `execute(x, f, a)` |
+| Single | One-way | Never-blocking | `x.post(f)` <br/> `x.post(f, a)` <br/> `x.defer(f)`  <br/> `x.defer(f, a)` | `post(x, f)` <br/> `post(x, f, a)` <br/> `defer(x, f)`  <br/> `defer(x, f, a)` |
+| Single | Two-way synchronous | Possibly-blocking | `x.sync_execute(f)` <br/> `x.sync_execute(f, a)` | `sync_execute(x, f)` <br/> `sync_execute(x, f, a)` |
+| Single | Two-way synchronous | Never-blocking | NA | NA |
+| Single | Two-way asynchronous | Possibly-blocking | `x.async_execute(f)` <br/> `x.async_execute(f, a)`  <br/> `x.then_execute(f, pred)` <br/> `x.then_execute(f, pred, a)` | `async_execute(x, f)` <br/> `async_execute(x, f, a)`  <br/> `then_execute(x, f, pred)` <br/> `then_execute(x, f, pred, a)` |
+| Single | Two-way asynchronous | Never-blocking | `x.async_post(f)` <br/> `x.async_post(f, a)` <br/> `x.async_defer(f)` <br/> `x.async_defer(f, a)` | `async_post(x, f)` <br/> `x.async_post(x, f, a)` <br/> `async_defer(x, f)` <br/> `x.async_defer(x, f, a)` |
+| Bulk | One-way | Possibly-blocking | `x.bulk_execute(f, n, sf)` | `bulk_execute(x, f, n, sf)` |
+| Bulk | One-way | Never-blocking | `x.bulk_post(f, n, sf)` <br/> `x.bulk_defer(f, n, sf)` | `bulk_post(x, f, n, sf)` <br/> `bulk_defer(x, f, n, sf)` |
+| Bulk | Two-way synchronous | Possibly-blocking | `x.bulk_sync_execute(f, n, rf, sf)` | `bulk_sync_execute(x, f, n, rf, sf)` |
+| Bulk | Two-way synchronous | Never-blocking | NA | NA |
+| Bulk | Two-way asynchronous | Possibly-blocking | `x.bulk_async_execute(f, n, rf, sf)` <br/> `x.bulk_then_execute(f, n, pred, rf, sf)` | `bulk_async_execute(x, f, n, rf, sf)` <br/> `bulk_then_execute(x, f, n, pred, rf, sf)` |
+| Bulk | Two-way asynchronous | Never-blocking |  `x.bulk_async_post(f, n, rf, sf)` <br/> `x.bulk_async_defer(f, n, rf, sf)` | `bulk_async_post(x, f, n, rf, sf)` <br/> `bulk_async_defer(x, f, n, rf, sf)` |
 
 ### `BaseExecutor` requirements
 
@@ -486,11 +486,11 @@ The `OneWayExecutor` requirements specify requirements for executors which creat
 
 A type `X` satisfies the `OneWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, and `can_execute_v<X>` is true.
 
-### `NonBlockingOneWayExecutor` requirements
+### `NeverBlockingOneWayExecutor` requirements
 
-The `NonBlockingOneWayExecutor` requirements refine the `OneWayExecutor` requirements by adding one-way operations that are guaranteed not to block the caller pending completion of submitted function objects.
+The `NeverBlockingOneWayExecutor` requirements refine the `OneWayExecutor` requirements by adding one-way operations that are guaranteed not to block the caller pending completion of submitted function objects.
 
-A type `X` satisfies the `NonBlockingOneWayExecutor` requirements if it satisfies the `OneWayExecutor` requirements, `can_post_v<X>` is true, and `can_defer_v<X>` is true.
+A type `X` satisfies the `NeverBlockingOneWayExecutor` requirements if it satisfies the `OneWayExecutor` requirements, `can_post_v<X>` is true, and `can_defer_v<X>` is true.
 
 ### `TwoWayExecutor` requirements
 
@@ -551,22 +551,22 @@ This sub-clause contains templates that may be used to query the properties of a
 
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/>`struct has_execute_member` | `T` has a member function named `execute` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_post_member` | `T` has a member function named `post` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_defer_member` | `T` has a member function named `defer` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_execute_member` | `T` has a member function named `execute` that satisfies the syntactic requirements of a one-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_post_member` | `T` has a member function named `post` that satisfies the syntactic requirements of a one-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_defer_member` | `T` has a member function named `defer` that satisfies the syntactic requirements of a one-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
 | `template<class T>` <br/>`struct has_sync_execute_member` | `T` has a member function named `sync_execute` that satisfies the syntactic requirements of a synchronous two-way execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_execute_member` | `T` has a member function named `async_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_post_member` | `T` has a member function named `async_post` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_defer_member` | `T` has a member function named `async_defer` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_then_execute_member` | `T` has a member function named `then_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_execute_member` | `T` has a member function named `bulk_execute` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_post_member` | `T` has a member function named `bulk_post` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_defer_member` | `T` has a member function named `bulk_defer` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_execute_member` | `T` has a member function named `async_execute` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_post_member` | `T` has a member function named `async_post` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_defer_member` | `T` has a member function named `async_defer` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_then_execute_member` | `T` has a member function named `then_execute` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_execute_member` | `T` has a member function named `bulk_execute` that satisfies the syntactic requirements of a one-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_post_member` | `T` has a member function named `bulk_post` that satisfies the syntactic requirements of a one-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_defer_member` | `T` has a member function named `bulk_defer` that satisfies the syntactic requirements of a one-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
 | `template<class T>` <br/>`struct has_bulk_sync_execute_member` | `T` has a member function named `bulk_sync_execute` that satisfies the syntactic requirements of a synchronous two-way execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_execute_member` | `T` has a member function named `bulk_async_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_post_member` | `T` has a member function named `bulk_async_post` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_defer_member` | `T` has a member function named `bulk_async_defer` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_then_execute_member` | `T` has a member function named `bulk_then_execute` that satisfies the syntactic requirements of an a asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_execute_member` | `T` has a member function named `bulk_async_execute` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_post_member` | `T` has a member function named `bulk_async_post` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_defer_member` | `T` has a member function named `bulk_async_defer` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_then_execute_member` | `T` has a member function named `bulk_then_execute` that satisfies the syntactic requirements of an a asynchronous two-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
 
 ### Free function detection type traits
 
@@ -591,22 +591,22 @@ This sub-clause contains templates that may be used to query the properties of a
 
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/>`struct has_execute_free_function` | There exists a free function named `execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_post_free_function` | There exists a free function named `post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_defer_free_function` | There exists a free function named `defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_execute_free_function` | There exists a free function named `execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_post_free_function` | There exists a free function named `post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_defer_free_function` | There exists a free function named `defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
 | `template<class T>` <br/>`struct has_sync_execute_free_function` | There exists a free function named `sync_execute` taking an executor of type `T` that satisfies the syntactic requirements of a synchronous two-way execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_execute_free_function` | There exists a free function named `async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_post_free_function` | There exists a free function named `async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_defer_free_function` | There exists a free function named `async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_then_execute_free_function` | There exists a free function named `then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_execute_free_function` | There exists a free function named `bulk_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_post_free_function` | There exists a free function named `bulk_post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_defer_free_function` | There exists a free function named `bulk_defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_execute_free_function` | There exists a free function named `async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_post_free_function` | There exists a free function named `async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_async_defer_free_function` | There exists a free function named `async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_then_execute_free_function` | There exists a free function named `then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_execute_free_function` | There exists a free function named `bulk_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_post_free_function` | There exists a free function named `bulk_post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_defer_free_function` | There exists a free function named `bulk_defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
 | `template<class T>` <br/>`struct has_bulk_sync_execute_free_function` | There exists a free function named `bulk_sync_execute` taking an executor of type `T` that satisfies the syntactic requirements of a synchronous two-way execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_execute_free_function` | There exists a free function named `bulk_async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_post_free_function` | There exists a free function named `bulk_async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_defer_free_function` | There exists a free function named `bulk_async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_then_execute_free_function` | There exists a free function named `bulk_then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_execute_free_function` | There exists a free function named `bulk_async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_post_free_function` | There exists a free function named `bulk_async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_async_defer_free_function` | There exists a free function named `bulk_async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, never-blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_then_execute_free_function` | There exists a free function named `bulk_then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an an asynchronous two-way, possibly-blocking execution function of bulk cardinality. | `T` is a complete type. |
 
 ## Executor customization points
 
@@ -644,7 +644,7 @@ The name `post` denotes a customization point. The effect of the expression `std
 
 * Otherwise, `post(E, F, A...)` if `has_post_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::post(E, F, A...)` is ill-formed.
 
@@ -660,7 +660,7 @@ The name `defer` denotes a customization point. The effect of the expression `st
 
 * Otherwise, `defer(E, F, A...)` if `has_defer_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::defer(E, F, A...)` is ill-formed.
 
@@ -708,7 +708,7 @@ The name `async_post` denotes a customization point. The effect of the expressio
 
 * Otherwise, `async_post(E, F, A...)` if `has_async_post_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, if `can_post_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `async_post`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::async_post(E, F, A...)` is an object of type `std::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
 
@@ -726,7 +726,7 @@ The name `async_defer` denotes a customization point. The effect of the expressi
 
 * Otherwise, `async_defer(E, F, A...)` if `has_async_defer_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, if `can_defer_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `async_defer`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::async_defer(E, F, A...)` is an object of type `std::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
 
@@ -791,7 +791,7 @@ The name `bulk_post` denotes a customization point. The effect of the expression
 
 * Otherwise, `bulk_post(E, F, S, SF)` if `has_bulk_post_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::bulk_post(E, F, S, SF)` is ill-formed.
 
@@ -807,7 +807,7 @@ The name `bulk_defer` denotes a customization point. The effect of the expressio
 
 * Otherwise, `bulk_defer(E, F, S, SF)` if `has_bulk_defer_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::bulk_defer(E, F, S, SF)` is ill-formed.
 
@@ -855,7 +855,7 @@ The name `bulk_async_post` denotes a customization point. The effect of the expr
 
 * Otherwise, `bulk_async_post(E, F, S, RF, SF)` if `has_bulk_async_post_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_post(E, F)` is ill-formed.
 
@@ -871,7 +871,7 @@ The name `bulk_async_defer` denotes a customization point. The effect of the exp
 
 * Otherwise, `bulk_async_defer(E, F, S, RF, SF)` if `has_bulk_async_defer_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_category_t<decay_t<decltype(E)>>, non_blocking_execution_tag>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
 * Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_defer(E, F)` is ill-formed.
 
@@ -990,7 +990,7 @@ In the Table below,
 ### Determining that a type satisfies executor category requirements
 
     template<class T> struct is_one_way_executor;
-    template<class T> struct is_non_blocking_one_way_executor;
+    template<class T> struct is_never_blocking_one_way_executor;
     template<class T> struct is_two_way_executor;
     template<class T> struct is_bulk_two_way_executor;
 
@@ -999,7 +999,7 @@ This sub-clause contains templates that may be used to query the properties of a
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
 | `template<class T>` <br/>`struct is_one_way_executor` | `T` meets the syntactic requirements for `OneWayExecutor`. | `T` is a complete type. |
-| `template<class T>` <br/>`struct is_non_blocking_one_way_executor` | `T` meets the syntactic requirements for `NonBlockingOneWayExecutor`. | `T` is a complete type. |
+| `template<class T>` <br/>`struct is_never_blocking_one_way_executor` | `T` meets the syntactic requirements for `NeverBlockingOneWayExecutor`. | `T` is a complete type. |
 | `template<class T>` <br/>`struct is_two_way_executor` | `T` meets the syntactic requirements for `TwoWayExecutor`. | `T` is a complete type. |
 | `template<class T>` <br/>`struct is_bulk_two_way_executor` | `T` meets the syntactic requirements for `BulkTwoWayExecutor`. | `T` is a complete type. |
 
@@ -1027,7 +1027,7 @@ The type of `executor_future<Executor, T>::type` is determined as follows:
 
 * otherwise, the program is ill formed.
 
-[*Note:* The effect of this specification is that all execute functions of an executor that satisfies the `TwoWayExecutor`, `NonBlockingTwoWayExecutor`, or `BulkTwoWayExecutor` requirements must utilize the same future type, and that this future type is determined by `async_execute`. Programs may specialize this trait for user-defined `Executor` types. *--end note*]
+[*Note:* The effect of this specification is that all execute functions of an executor that satisfies the `TwoWayExecutor`, `NeverBlockingTwoWayExecutor`, or `BulkTwoWayExecutor` requirements must utilize the same future type, and that this future type is determined by `async_execute`. Programs may specialize this trait for user-defined `Executor` types. *--end note*]
 
 ### Classifying the mapping of execution agents
 
@@ -1071,45 +1071,45 @@ agent executes as-if on a `std::thread`. Therefore, the facilities provided by
 particular that thread-local storage will not be shared between execution
 agents. *--end note*]
 
-### Classifying the blocking behavior of potentially blocking operations
+### Guaranteeing the blocking behavior of potentially blocking operations
 
-    struct blocking_execution_tag {};
-    struct possibly_blocking_execution_tag {};
-    struct non_blocking_execution_tag {};
+    struct always_blocking_execution {};
+    struct possibly_blocking_execution {};
+    struct never_blocking_execution {};
 
     template<class Executor>
-    struct executor_execute_blocking_category
+    struct executor_execute_blocking_guarantee
     {
       private:
         // exposition only
         template<class T>
-        using helper = typename T::blocking_category;
+        using helper = typename T::blocking_guarantee;
 
       public:
         using type = std::experimental::detected_or_t<
-          possibly_blocking_execution_tag, helper, Executor
+          possibly_blocking_execution, helper, Executor
         >;
     };
 
-Components which create possibly blocking execution may use *blocking categories*
+Components which create potentially blocking execution may use *blocking guarantees*
 to communicate the way in which this execution blocks the progress of its caller.
 
-`blocking_execution_tag` indicates that a component blocks its caller's
+`always_blocking_execution` indicates that a component blocks its caller's
 progress pending the completion of the execution agents created by that component.
 
-`possibly_blocking_execution_tag` indicates that a component may block its
+`possibly_blocking_execution` indicates that a component may block its
 caller's progress pending the completion of the execution agents created by that
 component.
 
-`non_blocking_execution_tag` indicates that a component does not block its
+`never_blocking_execution` indicates that a component does not block its
 caller's progress pending the completion of the execution agents created by that
 component.
 
-Programs may use `executor_execute_blocking_category` to query the blocking behavior of
+Programs may use `executor_execute_blocking_guarantee` to query the blocking behavior of
 executor customization points whose semantics allow the possibility of
 blocking.
 
-[*Note:* These customization points which allow the possibility of blocking are `execute`, `async_execute`, `then_execute`, `bulk_execute`, `bulk_async_execute`, and `bulk_then_execute`. *--end note*]
+[*Note:* These customization points which potentially block are `execute`, `async_execute`, `then_execute`, `bulk_execute`, `bulk_async_execute`, and `bulk_then_execute`. *--end note*]
 
 ## Bulk executor traits
 
@@ -1541,12 +1541,12 @@ Let `e` be the target object of `*this`. Let `a1` be the allocator that was spec
 
 *Effects:* Performs `e.execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
-### Class `non_blocking_one_way_executor`
+### Class `never_blocking_one_way_executor`
 
-Class `non_blocking_one_way_executor` satisfies the general requirements on polymorphic executor wrappers, with the additional definitions below.
+Class `never_blocking_one_way_executor` satisfies the general requirements on polymorphic executor wrappers, with the additional definitions below.
 
 ```
-class non_blocking_one_way_executor
+class never_blocking_one_way_executor
 {
 public:
   // execution agent creation
@@ -1559,7 +1559,7 @@ public:
 };
 ```
 
-Class `non_blocking_one_way_executor` satisfies the `NonBlockingOneWayExecutor` requirements. The target object shall satisfy the `NonBlockingOneWayExecutor` requirements.
+Class `never_blocking_one_way_executor` satisfies the `NeverBlockingOneWayExecutor` requirements. The target object shall satisfy the `NeverBlockingOneWayExecutor` requirements.
 
 ```
 template<class Function, class ProtoAllocator>
@@ -1802,7 +1802,7 @@ class static_thread_pool::executor_type
     // types:
 
     typedef parallel_execution_tag execution_category;
-    typedef possibly_blocking_execution_tag blocking_category;
+    typedef possibly_blocking_execution blocking_guarantee;
     typedef std::size_t shape_type;
     typedef std::size_t index_type;
 
@@ -2039,7 +2039,7 @@ particular type of `OneWayExecutor` that cannot block in `.execute()`.
 `.then()` stores `f` as the next continuation in the future state, and when
 the future is ready, creates an execution agent using a copy of `exec`.
 
-One approach is for `.then()` to require a `NonBlockingOneWayExecutor`, and to
+One approach is for `.then()` to require a `NeverBlockingOneWayExecutor`, and to
 specify that `.then()` submits the continuation using `exec.post()` if the
 future is already ready at the time when `.then()` is called, and to submit
 using `exec.execute()` otherwise.
@@ -2064,7 +2064,7 @@ particular type of `OneWayExecutor` that cannot block in `.execute()`.
 state, and when the underlying future is ready, creates an execution agent
 using a copy of `exec`.
 
-One approach is for `.then()` to require a `NonBlockingOneWayExecutor`, and to
+One approach is for `.then()` to require a `NeverBlockingOneWayExecutor`, and to
 specify that `.then()` submits the continuation using `exec.post()` if the
 future is already ready at the time when `.then()` is called, and to submit
 using `exec.execute()` otherwise.
@@ -2130,7 +2130,7 @@ Executors in the Networking TS may be defined as refinements of the type require
 
 ### `NetworkingExecutor` requirements
 
-A type `X` satisfies the `NetworkingExecutor` requirements if it satisfies the `NonBlockingOneWayExecutor` requirements, the `ExecutorWorkTracker` requirements, and satisfies the additional requirements listed below.
+A type `X` satisfies the `NetworkingExecutor` requirements if it satisfies the `NeverBlockingOneWayExecutor` requirements, the `ExecutorWorkTracker` requirements, and satisfies the additional requirements listed below.
 
 In the Table \ref{net_execution_context_requirements} below, `x` denotes a (possibly const) value of type `X`.
 


### PR DESCRIPTION
* executor_execute_blocking_category -> executor_execute_blocking_guarantee
* executor_execute_blocking_category_t -> executor_execute_blocking_guarantee_t
* blocking_execution_tag -> always_blocking_execution
* possibly_blocking_execution_tag -> possibly_blocking_execution
* non_blocking_execution_tag -> never_blocking_execution
* is_non_blocking_one_way_executor -> is_never_blocking_one_way_executor
* is_non_blocking_one_way_executor_v -> is_never_blocking_one_way_executor_v
* non_blocking_one_way_executor -> never_blocking_one_way_executor

Consistenly use the terms "always-blocking", "possibly-blocking", and "never-blocking".

Change some uses of "potentially blocking" to "possibly-blocking" where appropriate.

Fixes #180