### PR TITLE
sync_ functions return Futures and one-way functions shall not throw user exceptions

### DIFF
--- a/explanatory.md
+++ b/explanatory.md
@@ -536,18 +536,19 @@ create multiple agents in bulk have names prefixed with `bulk_`;
 single-agent customization points have no prefix. 
 
 **Directionality.** Some executor customization points return a `Future` object
-for synchronizing with and retrieving the result or exception of execution. Other
-customization points allow clients to "fire-and-forget" their execution and
-return no `Future`. We refer to fire-and-forgetful customization points as
+for synchronizing with and retrieving the result or exception of execution.
+Other customization points allow clients to "fire-and-forget" their execution
+and return no `Future`. We refer to fire-and-forgetful customization points as
 "one-way" while those that provide a synchronization channel are
 "two-way"[^directionality_caveat]. Two-way customization points allow executors
 to participate directly in delivering the result of execution rather than
 require inefficient synchronization out-of-band. On the other hand, when
 synchronization is not required (perhaps when some other backchannel is
     available), one-way customization points avoid the cost of a `Future` and
-shield the user from exceptional execution. The names of two-way customization
-points names are infixed with `sync_`, `async_`, or `then_`.  One-way
-customization points have no infix.
+shield the user from exceptional execution. In these cases, a one-way executor
+may provide a backchannel for communicating user exceptions back to the client.
+The names of two-way customization points names are infixed with `sync_`,
+    `async_`, or `then_`.  One-way customization points have no infix.
 
 [^directionality_caveat]: We think that the names "one-way" and "two-way" should be improved.
 

--- a/explanatory.md
+++ b/explanatory.md
@@ -1162,7 +1162,7 @@ wait for execution to complete containing the result of `result_factory`. Each
 created execution agent calls `std::forward<Function>(func)(i, r, s)`, where `i`
 is of type `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
-`bulk_async_post` may or may not the caller until execution completes, depending
+`bulk_async_execute` may or may not block the caller until execution completes, depending
 on the value of `executor_execute_blocking_category_t<Executor>`.
 
 Like `bulk_then_execute`, `bulk_async_execute`

--- a/explanatory.md
+++ b/explanatory.md
@@ -535,20 +535,21 @@ to the important special case of a single agent. Customization points which
 create multiple agents in bulk have names prefixed with `bulk_`;
 single-agent customization points have no prefix. 
 
-**Directionality.** Some executor customization points return a channel back to
-the client for synchronizing with the result of execution. For asynchronous
-customization points, this channel is a future object corresponding to an
-eventual result. For synchronous customization points, this channel is simply
-the result itself. Other customization points allow clients to
-"fire-and-forget" their execution and return no such channel. We refer to
-fire-and-forgetful customization points as "one-way" while those that provide a
-synchronization channel are "two-way"[^directionality_caveat]. Two-way
-customization points allow executors to participate directly in synchronization rather
-than require inefficient synchronization out-of-band. On the other hand, when
-synchronization is not required, one-way customization points avoid the cost of
-a synchronization channel. The names of two-way customization points names are
-infixed with `sync_`, `async_`, or `then_`.  One-way customization points have
-no infix.
+**Directionality.** Some executor customization points return a `Future` object
+for synchronizing with and retrieving the result of execution. Other
+customization points allow clients to "fire-and-forget" their execution and
+return no `Future`. We refer to fire-and-forgetful customization points as
+"one-way" while those that provide a synchronization channel are
+"two-way"[^directionality_caveat].  Two-way customization points allow
+executors to participate directly in synchronization rather than require
+inefficient synchronization out-of-band.  Moreover, these customization points
+allow the executor to participate directly in delivering the result of
+execution or indicating an exception. On the other hand, when synchronization
+is not required (perhaps when some other backchannel is available), one-way
+customization points avoid the cost of a `Future` and shield the user from
+exceptional execution. The names of two-way customization points
+names are infixed with `sync_`, `async_`, or `then_`.  One-way customization
+points have no infix.
 
 [^directionality_caveat]: We think that the names "one-way" and "two-way" should be improved.
 
@@ -788,11 +789,12 @@ As a simple example, consider the adaptation performed by
 `execution::sync_execute` when a given executor provides no native support:
 
     template<class Executor, class Function>
-    std::invoke_result_t<std::decay_t<Function>>
+    executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>>>
     sync_execute(const Executor& exec, Function&& f)
     {
       auto future = execution::async_execute(exec, std::forward<Function>(f));
-      return future.get();
+      future.wait();
+      return future;
     }
 
 In this case, `execution::sync_execute` creates asynchronous execution via
@@ -852,7 +854,8 @@ executor which always creates execution "inline":
 
       template<class Function>
       auto sync_execute(Function&& f) const {
-        return std::forward<Function>(f)();
+        using result_type = std::invoke_result_t<Function>;
+        return make_ready_future<result_type>(std::forward<Function>(f)());
       }
     };
 
@@ -1131,7 +1134,7 @@ functionality by making a call to `bulk_sync_execute` inside a continuation
 created by `predecessor_future.then`:
 
     predecessor_future.then([=] {
-      return exec.bulk_sync_execute(exec, f, shape, result_factory, shared_factory);
+      return exec.bulk_sync_execute(exec, f, shape, result_factory, shared_factory).get();
     });
 
 Note that this implementation creates `1 + shape` execution agents: one agent
@@ -1148,7 +1151,7 @@ unacceptable.
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
-    executor_future_t<std::invoke_result_t<std::decay_t<ResultFactory>>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
     bulk_async_execute(const Executor& exec, Function&& func,
                        executor_shape_t<Executor> shape,
                        ResultFactory result_factory,
@@ -1193,7 +1196,7 @@ require accommodating a predecessor dependency.
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
-    executor_future_t<std::invoke_result_t<std::decay_t<ResultFactory>>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
     bulk_async_post(const Executor& exec, Function&& func,
                     executor_shape_t<Executor> shape,
                     ResultFactory result_factory,
@@ -1256,7 +1259,7 @@ the executor implementation.
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
-    std::invoke_result_t<std::decay_t<Function>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
     bulk_sync_execute(const Executor& exec, Function&& func,
                       executor_shape_t<Executor> shape,
                       ResultFactory result_factory,
@@ -1274,18 +1277,17 @@ whose execution may begin immediately and returns the result of
 regardless of the value of `executor_execute_blocking_category_t<Executor>`.
 
 `bulk_sync_execute` is equivalent to `bulk_async_execute` except that it blocks
-its client until the result of execution is complete. It returns this result
-directly as a value, rather than indirectly via a future object.
-Correspondingly, it may be implemented by calling `bulk_async_execute` and
-getting the future's result:
+its client until the result of execution is complete. Correspondingly, it may
+be implemented by calling `bulk_async_execute` and waiting on the resulting future:
 
     auto future = exec.bulk_async_execute(f, shape, result_factory, shared_factory);
-    return future.get();
+    future.wait();
+    return future;
 
-Like `bulk_async_execute`, we include `bulk_sync_execute` to avoid overhead
-incurred by introducing a temporary future object. This overhead is likely to
-be significant for executors whose cost of execution agent creation is very
-small. A hypothetical `simd_executor` or `inline_executor` are examples.
+We include `bulk_sync_execute` to avoid overhead incurred by introducing
+unnecessary asynchrony. This overhead is likely to be significant for executors
+whose cost of execution agent creation is very small. A hypothetical
+`simd_executor` or `inline_executor` are examples.
 
 ## Two-Way Single-Agent Functions
 
@@ -1379,7 +1381,7 @@ may be significant and can be avoided if an executor specializes `then_execute`.
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
-    executor_future_t<std::invoke_result_t<std::decay_t<Function>>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
     async_execute(const Executor& exec, Function&& func,
                   Allocator& alloc = Allocator());
 
@@ -1424,7 +1426,7 @@ requiring executors to explicitly support continuations with `then_execute`, inc
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
-    executor_future_t<std::invoke_result_t<std::decay_t<Function>>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
     async_post(const Executor& exec, Function&& func,
                Allocator& alloc = Allocator());
 
@@ -1448,7 +1450,7 @@ possible only if `executor_execute_blocking_category_t<Executor>` is
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
-    executor_future_t<std::invoke_result_t<std::decay_t<Function>>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
     async_defer(const Executor& exec, Function&& func,
                 Allocator& alloc = Allocator());
 
@@ -1478,7 +1480,7 @@ optimizations within the executor implementation.
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
-    std::invoke_result_t<std::decay_t<Function>>
+    executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>>>
     sync_execute(const Executor& exec, Function&& func,
                  Allocator& alloc = Allocator());
 
@@ -1489,17 +1491,17 @@ executor `exec` whose execution may begin immediately and returns the result of
 `alloc` can be used to allocate memory for `func`.
 
 `sync_execute` is equivalent to `async_execute` except that it blocks its
-client until the result of execution is complete. It returns this result
-directly as a value, rather than indirectly via a future object.
-Correspondingly, it may be implemented by calling `async_execute` and getting the future's result:
+client until the result of execution is complete. 
+Correspondingly, it may be implemented by calling `async_execute` and waiting on the resulting future:
 
     auto future = exec.async_execute(std::forward<Function>(f));
-    return future.get();
+    future.wait();
+    return future;
 
-Like `async_execute`, we include `sync_execute` to avoid overhead incurred by
-introducing a temporary future object. This overhead is likely to be
-significant for executors whose cost of execution agent creation is very small.
-A hypothetical `simd_executor` or `inline_executor` are examples.
+We include `sync_execute` to avoid overhead incurred by introducing unnecessary
+asynchrony. This overhead is likely to be significant for executors whose cost
+of execution agent creation is very small. A hypothetical `simd_executor` or
+`inline_executor` are examples.
 
 We believe it is possible to make the cost of the future arbitrarily small in
 very special cases. For example, if the executor's associated future is a
@@ -1829,20 +1831,6 @@ results do not require expensive dynamic allocation or synchronization
 primitives of full-fledged `std::future` objects. We envision that a
 separate effort will propose a `Future` concept which would introduce
 requirements for these user-defined `std::future`-like types.
-
-### Error Handling
-
-Our proposal prescribes no mechanism for execution functions to communicate
-exceptional behavior back to their clients. For our purposes, exceptional
-behavior includes exceptions thrown by the callable functions invoked by
-execution agents and failures to create those execution agents due to resource
-exhaustion. In most cases, resource exhaustion can be reported immediately
-similar to `std::async`'s behavior. Reporting exceptions encountered by
-execution agents can also be generalized from `std::async`. We envision that
-asynchronous two-way functions will report errors through an exceptional future
-object, and synchronous two-way functions will simply throw any exceptions they
-encounter as normal. However, it is not clear what mechanism, if any, one-way
-execution functions should use for error reporting.
 
 ### Additional Thread Pool Types
 

--- a/explanatory.md
+++ b/explanatory.md
@@ -536,20 +536,18 @@ create multiple agents in bulk have names prefixed with `bulk_`;
 single-agent customization points have no prefix. 
 
 **Directionality.** Some executor customization points return a `Future` object
-for synchronizing with and retrieving the result of execution. Other
+for synchronizing with and retrieving the result or exception of execution. Other
 customization points allow clients to "fire-and-forget" their execution and
 return no `Future`. We refer to fire-and-forgetful customization points as
 "one-way" while those that provide a synchronization channel are
-"two-way"[^directionality_caveat].  Two-way customization points allow
-executors to participate directly in synchronization rather than require
-inefficient synchronization out-of-band.  Moreover, these customization points
-allow the executor to participate directly in delivering the result of
-execution or indicating an exception. On the other hand, when synchronization
-is not required (perhaps when some other backchannel is available), one-way
-customization points avoid the cost of a `Future` and shield the user from
-exceptional execution. The names of two-way customization points
-names are infixed with `sync_`, `async_`, or `then_`.  One-way customization
-points have no infix.
+"two-way"[^directionality_caveat]. Two-way customization points allow executors
+to participate directly in delivering the result of execution rather than
+require inefficient synchronization out-of-band. On the other hand, when
+synchronization is not required (perhaps when some other backchannel is
+    available), one-way customization points avoid the cost of a `Future` and
+shield the user from exceptional execution. The names of two-way customization
+points names are infixed with `sync_`, `async_`, or `then_`.  One-way
+customization points have no infix.
 
 [^directionality_caveat]: We think that the names "one-way" and "two-way" should be improved.
 

--- a/wording.md
+++ b/wording.md
@@ -375,9 +375,9 @@ In the Table below, `x` denotes a (possibly const) executor object of type `X` a
 
 The directionality property of an execution function may be one of the following:
 
-* *One-way:* The execution function creates execution agents without a channel for awaiting the completion of a submitted function object or for obtaining its result. *Note:* That is, the executor provides fire-and-forget semantics. *--end note*] The names of execution functions having one-way directionality do not have an associated prefix.
-* *Synchronous two-way:* The execution function blocks until execution of the submitted function is complete, and returns the result. The names of execution functions having synchronous two-way directionality have the prefix `sync_`.
-* *Asynchronous two-way:* The execution function returns a `Future` for awaiting the completion of a submitted function object and obtaining its result. The names of execution functions having asynchronous two-way directionality have the prefix `async_` or `then_`.
+* *One-way:* The execution function creates execution agents without returning a `Future` for awaiting the completion of a submitted function object or for obtaining its result or exception. *Note:* That is, the executor provides fire-and-forget semantics. *--end note*] The names of execution functions having one-way directionality do not have an associated prefix.
+* *Synchronous two-way:* The execution function blocks until execution of the submitted function is complete, and returns a ready `Future` for obtaining the function object's result or exception. The names of execution functions having synchronous two-way directionality have the prefix `sync_`.
+* *Asynchronous two-way:* The execution function returns a `Future` for awaiting the completion of a submitted function object and obtaining its result or exception. The names of execution functions having asynchronous two-way directionality have the prefix `async_` or `then_`.
 
 ##### Requirements on execution functions of one-way directionality
 
@@ -385,23 +385,15 @@ In the Table below, `x` denotes a (possibly const) executor object of type `X`, 
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.'e'(...)` <br/> `'e'(x, ...)` | void | [*Note:* If `f()` exits via an exception, the behavior is specific to the executor. *--end note.*] |
+| `x.'e'(...)` <br/> `'e'(x, ...)` | void | Shall not exit via any exception thrown by `f()`. [*Note:* If `f()` exits via an exception, the behavior is specific to the executor, as long as that exception is not thrown. *--end note.*] |
 
-##### Requirements on execution functions of synchronous two-way directionality
-
-In the Table below, `x` denotes a (possibly const) executor object of type `X`, `'e'` denotes an expression from the requirements on blocking semantics and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
-
-| Expression | Return Type | Operational semantics |
-|------------|-------------|---------------------- |
-| `x.sync_'e'(...)` <br/> `sync_'e'(x, ...)` | `R` | Returns the result of `f()`. <br/><br/> Throws any exception thrown by `f()`. <br/> <br/> Must block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. |
-
-##### Requirements on execution functions of asynchronous two-way directionality
+##### Requirements on execution functions of two-way directionality
 
 In the Table below, `x` denotes a (possibly const) executor object of type `X`, `'e'` denotes an expression from the requirements on blocking semantics, `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements and `pred` denotes a `Future` object whose result is `pr`.
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.async_'e'(...)` <br/> `async_'e'(x, ...)` | A type that satisfies the `Future` requirements for the value type `R`. |  Stores the result of `f()`, or any exception thrown by `f()`, in the associated shared state of the resulting `Future`. |
+| `x.async_'e'(...)` <br/> `async_'e'(x, ...)` <br/> `x.sync_'e'(...)` <br/> `sync_'e'(x, ...)` | A type that satisfies the `Future` requirements for the value type `R`. |  Stores the result of `f()`, or any exception thrown by `f()`, in the associated shared state of the resulting `Future`. |
 | `x.then_'e'(..., pred, ...)` <br/> `then_'e'(x, ..., pred, ...)` | A type that satisfies the `Future` requirements for the value type `R`. | Stores the result of `f(pr)`, or any exception thrown by `f(pr)`, in the associated shared state of the resulting `Future`. |
 
 #### Cardinality
@@ -482,7 +474,7 @@ Table: (Base executor requirements) \label{base_executor_requirements}
 
 ### `OneWayExecutor` requirements
 
-The `OneWayExecutor` requirements specify requirements for executors which create execution agents without a channel for awaiting the completion of a submitted function object and obtaining its result. [*Note:* That is, the executor provides fire-and-forget semantics. *--end note*]
+The `OneWayExecutor` requirements specify requirements for executors which create execution agents and do not return a `Future` for awaiting the completion of a submitted function object and obtaining its result or exception. [*Note:* That is, the executor provides fire-and-forget semantics. *--end note*]
 
 A type `X` satisfies the `OneWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, and `can_execute_v<X>` is true.
 
@@ -495,16 +487,16 @@ A type `X` satisfies the `NonBlockingOneWayExecutor` requirements if it satisfie
 ### `TwoWayExecutor` requirements
 
 The `TwoWayExecutor` requirements specify requirements for executors which
-creating execution agents with a channel for awaiting the completion of a
-submitted function object and obtaining its result.
+creating execution agents and return a `Future` for awaiting the completion of a
+submitted function object and obtaining its result or exception.
 
 A type `X` satisfies the `TwoWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, `can_sync_execute_v<X>` is true, and `can_async_execute_v<X>` is true.
 
 ### `BulkTwoWayExecutor` requirements
 
 The `BulkTwoWayExecutor` requirements specify requirements for executors which
-create groups of execution agents in bulk from a single execution function with
-a channel for awaiting the completion of a submitted function object invoked by
+create groups of execution agents in bulk from a single execution function and return
+a `Future` for awaiting the completion of a submitted function object invoked by
 those execution agents and obtaining its result.
 
 A type `X` satisfies the `BulkTwoWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, `can_bulk_sync_execute_v<X>` is true, `can_bulk_async_execute_v<X>` is true, and `can_bulk_then_execute_v<X>` is true.
@@ -676,7 +668,11 @@ The name `sync_execute` denotes a customization point. The effect of the express
 
 * Otherwise, `sync_execute(E, F, A...)` if `has_sync_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...).get()` if `can_async_execute_v<decay_t<decltype(E)>>` is true.
+* Otherwise, if `can_async_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+
+        auto __future = std::experimental::concurrency_v2::execution::async_execute(E, F, A...);
+        __future.wait();
+        return __future;
 
 * Otherwise, `std::experimental::concurrency_v2::execution::sync_execute(E, F, A...)` is ill-formed.
 
@@ -823,7 +819,11 @@ The name `bulk_sync_execute` denotes a customization point. The effect of the ex
 
 * Otherwise, `bulk_sync_execute(E, F, S, RF, SF)` if `has_bulk_sync_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF).get()` if `can_bulk_async_execute_v<decay_t<decltype(E)>>` is true.
+* Otherwise, if `can_bulk_async_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+
+        auto __future = std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF);
+        __future.wait();
+        return __future;
 
 * Otherwise, `std::experimental::concurrency_v2::execution::bulk_sync_execute(E, F, S, RF, SF)` is ill-formed.
 


### PR DESCRIPTION
These changes update `sync_` functions to return `executor_future_t` and also ban user exceptions from escaping one-way functions.