### PR TITLE
Add proposed changes for one-way always-blocking exec func and naming scheme

### DIFF
--- a/explanatory.md
+++ b/explanatory.md
@@ -43,7 +43,7 @@ facilities.
 
 **Synchronization.** Execution created through different facilities has
 different synchronization properties. For example, an OpenMP parallel for loop
-is synchronous because the spawning thread blocks until the loop is complete 
+is synchronous because the spawning thread blocks until the loop is complete
 due to an implicit barrier at the end of the parallel region by default.
 In contrast, the execution of GPU kernels is typically asynchronous; kernel
 launches return immediately and the launching thread continues its execution
@@ -276,9 +276,9 @@ the operation is complete. This object automatically calls the executor's
 
 If an asynchronous operation completes immediately (that is, within the
 asynchronous operation's initiating function), the completion handler is
-scheduled for invocation using the executor's `post` customization point:
+scheduled for invocation using the executor's `never_blocking_execute` customization point:
 
-    std::execution::post(ex,
+    std::execution::never_blocking_execute(ex,
         [h = std::move(completion_handler), my_result]() mutable
         {
           h(my_result);
@@ -291,7 +291,7 @@ other hand, if the operation completes later then the asynchronous operation
 invokes the completion handler using the possibly-blocking execution
 function:
 
-    std::execution::execute(ex,
+    std::execution::possibly_blocking_execute(ex,
         [h = std::move(completion_handler), my_result]() mutable
         {
           h(my_result);
@@ -305,7 +305,7 @@ Finally, if an asynchronous operation consists of multiple intermediate steps,
 these steps may be scheduled using the defer execution function:
 
     // asynchronous operation consists of multiple steps
-    std::execution::defer(my_intermediate_complete_handler)
+    std::execution::never_blocking_continuation_execute(my_intermediate_complete_handler)
 
 This informs the executor of the relationship between the intermediate
 completion handlers, and allows it to optimize the scheduling and invocation
@@ -410,7 +410,7 @@ believe many execution contexts will provide methods to create executors bound
 to them. For example, our proposal defines `static_thread_pool`, which is an
 execution context representing a simple, manually-sized thread pool. Clients
 may receive an executor which creates work on a `static_thread_pool` by calling
-its `.executor` method:  
+its `.executor` method:
 
     // create a thread pool with 4 threads
     static_thread_pool pool(4);
@@ -501,8 +501,8 @@ async(const Executor& exec, Function&& f, Args&&... args) {
   // bind together f with its arguments
   auto g = bind(forward<Function>(f), forward<Args>(args)...);
 
-  // implement with executor customization point async_execute
-  return execution::async_execute(exec, g);
+  // implement with executor customization point twoway_possibly_blocking_execute
+  return execution::twoway_possibly_blocking_execute(exec, g);
 }
 ```
 
@@ -511,9 +511,9 @@ arguments and forward this package along with the executor to an **executor
 customization point**. Executor customization points are functions for
 performing fundamental interactions with all types of
 executors[^customization_point_note]. In this case, that customization point is
-`execution::async_execute`, which uses the executor to create a single
+`execution::twoway_possibly_blocking_execute`, which uses the executor to create a single
 execution agent to invoke a function. The agent's execution is asynchronous,
-          and `execution::async_execute` returns a future corresponding to its
+          and `execution::twoway_possibly_blocking_execute` returns a future corresponding to its
           completion.
 
 [^customization_point_note]: The model for our design the one suggested by Niebler[-@Niebler15:N4381].
@@ -533,7 +533,7 @@ the cost of execution agent creation over multiple agents. By the same token,
 support for single-agent creation enables executors to apply optimizations
 to the important special case of a single agent. Customization points which
 create multiple agents in bulk have names prefixed with `bulk_`;
-single-agent customization points have no prefix. 
+single-agent customization points have no prefix.
 
 **Directionality.** Some executor customization points return a `Future` object
 for synchronizing with and retrieving the result or exception of execution.
@@ -558,50 +558,46 @@ Depending on the relationship between client and executed task, blocking
 guarantees may be critical to either program correctness or performance. A
 customization point may guarantee to always block, possibly block, or never
 block its client. Customization points which may possibly block its client are
-suffixed with `execute`. The exception to this rule are customization points
+suffixed with `possibly_blocking_execute`. The exception to this rule are customization points
 infixed with `sync_`. Because they always return the result of execution to
 their client as a value, there is no way for `sync_` customization points to
 execute without blocking their client. Customization points which will never
-block its client are suffixed with `post` or `defer`. `defer` indicates a
+block its client are suffixed with `never_blocking_execute` or `never_blocking_continuation_execute`. `never_blocking_continuation_execute` indicates a
 preference to treat the created execution as a continuation of the client while
-`post` indicates no such preference. A futher discussion of blocking guarantees
+`never_blocking_execute` indicates no such preference. A futher discussion of blocking guarantees
 can be found in the ongoing discussions section later in the paper.
 
 ## The Customization Points Provided by Our Design
 
 Combining these properties results in customization points with names like
-`execute` and `bulk_async_execute`. One goal of the naming scheme is to allow
+`possibly_blocking_execute` and `bulk_twoway_possibly_blocking_execute`. One goal of the naming scheme is to allow
 readers to understand, at a glance, the gross properties of the execution
-created by a call to a customization point. For example, `execute` is the
+created by a call to a customization point. For example, `possibly_blocking_execute` is the
 customization point which creates a single execution agent and provides the
-least guarantees about the agent it creates. `execute` provides no way to
+least guarantees about the agent it creates. `possibly_blocking_execute` provides no way to
 synchronize with the created execution, and this execution may or may not block
-the caller. On the other hand, `bulk_sync_execute` creates a group of execution
+the caller. On the other hand, `bulk_twoway_always_blocking_execute` creates a group of execution
 agents in bulk, and these execution agents clearly synchronize with the caller.
 
 Combining these three sets of properties yields the following table of customization points.
 
-| Name           | Cardinality | Directionality | Blocking |
-|----------------|-------------|----------------|----------|
-| `execute`      | single      | one-way        | possibly |
-| `post`         | single      | one-way        | no       |
-| `defer`        | single      | one-way        | no       |
-| `async_execute`| single      | two-way        | possibly |
-| `then_execute` | single      | two-way        | possibly |
-| `sync_execute` | single      | two-way        | yes      |
-| `async_post`   | single      | two-way        | no       |
-| `async_defer`  | single      | two-way        | no       |
-| `bulk_execute` | bulk        | one-way        | possibly |
-| `bulk_post`    | bulk        | one-way        | no       |
-| `bulk_defer`   | bulk        | one-way        | no       |
-| `bulk_async_execute` | bulk   | two-way        | possibly |
-| `bulk_then_execute`  | bulk   | two-way        | possibly |
-| `bulk_sync_execute`  | bulk   | two-way        | yes      |
-| `bulk_async_post`    | bulk   | two-way        | no       |
-| `bulk_async_defer`   | bulk   | two-way        | no       |
+| Cardinality | Directionality | Blocking           | Name            |
+|-------------|----------------|--------------------|-----------------|
+| single      | one-way        | possibly  | `possibly_blocking_execute` |
+| single      | one-way        | never     | `never_blocking_execute` <br/> `never_blocking_continuation_execute` |
+| single      | one-way        | always     | `always_blocking_execute` |
+| single      | two-way        | possibly  | `twoway_possibly_blocking_execute` <br/> `twoway_then_possibly_blocking_execute` |
+| single      | two-way        | never     | `twoway_never_blocking_execute` <br/> `twoway_never_blocking_continuation_execute` |
+| single      | two-way        | always     | `twoway_always_blocking_execute` |
+| bulk      | one-way        | possibly  | `bulk_possibly_blocking_execute` |
+| bulk      | one-way        | never     | `bulk_never_blocking_execute` <br/> `bulk_never_blocking_continuation_execute` |
+| bulk      | one-way        | always     | `bulk_always_blocking_execute` |
+| bulk      | two-way        | possibly  | `bulk_twoway_possibly_blocking_execute` <br/> `bulk_twoway_then_possibly_blocking_execute` |
+| bulk      | two-way        | never     | `bulk_twoway_never_blocking_execute` <br/> `bulk_twoway_never_blocking_continuation_execute` |
+| bulk      | two-way        | always     | `bulk_twoway_always_blocking_execute` |
 
 Note that the entire cross product of the three sets of properties is not
-represented in this table. For example, `then_post` does not exist. When
+represented in this table. For example, `twoway_then_never_blocking_execute` does not exist. When
 selecting customization points, we have made a trade-off between expressivity
 and minimalism guided by their usefulness to the Standard Library and the
 technical specifications we initially wish to target.
@@ -613,13 +609,13 @@ Ranges TS [@Niebler17:RangesTS] and are provided in the `execution` namespace.
 
 ### Single-Agent Interfaces
 
-First we describe single-agent customization points. For example, `execution::async_execute`: 
+First we describe single-agent customization points. For example, `execution::twoway_possibly_blocking_execute`: 
 
     namespace execution {
 
     template<class Executor, class Function>
     executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>>
-    async_execute(const Executor& exec, Function&& f);
+    twoway_possibly_blocking_execute(const Executor& exec, Function&& f);
 
     }
 
@@ -633,11 +629,11 @@ Single-agent, two-way customization points return the result of the callable
 object either directly, or through a future as shown above. One-way
 customization points always return `void`.
 
-For `then_execute`, the third parameter is a future which is the predecessor dependency for the execution:
+For `twoway_then_possibly_blocking_execute`, the third parameter is a future which is the predecessor dependency for the execution:
 
     template<class Executor, class Function, class Future>
     executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>,U&>>
-    then_execute(const Executor& exec, Function&& f, Future& predecessor_future);
+    twoway_then_possibly_blocking_execute(const Executor& exec, Function&& f, Future& predecessor_future);
 
 Let `U` be the type of `Future`'s result object. The callable object `f` is
 invoked with a reference to the result object of the predecessor future (or
@@ -645,7 +641,7 @@ invoked with a reference to the result object of the predecessor future (or
 with the interface of the Concurrency TS's `future::then` which invokes its
 continuation with a copy of the predecessor future. Our design avoids the
 composability issues of `future::then` [@Executors16:Issue96] and is consistent
-with `bulk_then_execute`, discussed below. Note that the type of `Future` is
+with `bulk_twoway_then_possibly_blocking_execute`, discussed below. Note that the type of `Future` is
 allowed to differ from `executor_future_t<Executor,U>`, enabling
 interoperability between executors and foreign or new future types.
 
@@ -667,14 +663,14 @@ given by `std::execution::executor_bulk_forward_progress_guarantee_t`. Because t
 multiple agents, bulk customization points introduce ownership and lifetime
 issues avoided by single-agent customization points and they include additional
 parameters to address these issues. For example, consider
-`execution::bulk_async_execute`:
+`execution::bulk_twoway_possibly_blocking_execute`:
 
     template<class Executor, class Function, class Factory1, class Factory2>
     executor_future_t<Executor,std::invoke_result_t<Factory1>>
-    bulk_async_execute(const Executor& exec, Function f, executor_shape_t<Executor> shape,
+    bulk_twoway_possibly_blocking_execute(const Executor& exec, Function f, executor_shape_t<Executor> shape,
                        Factory1 result_factory, Factory2 shared_parameter_factory);
 
-**Bulk results.** The first difference is that `bulk_async_execute` returns the
+**Bulk results.** The first difference is that `bulk_twoway_possibly_blocking_execute` returns the
 result of a **factory** rather than the result of `f`. Because bulk
 customization points create a group of execution agents which invoke multiple
 invocations of `f`, the result of execution is ambiguous. For example, all
@@ -734,12 +730,12 @@ storage and sharing schemes.
 
 [^factory_footnote]: This envisioned allocator support is why we refer to these callable objects as "factories" rather than simply "functions" or "callable objects".
 
-**Bulk continuations.** Like `then_execute`, `bulk_then_execute` introduces a
+**Bulk continuations.** Like `bulk_twoway_then_possibly_blocking_execute`, `bulk_twoway_then_possibly_blocking_execute` introduces a
 predecessor future upon which the bulk continuation depends:
 
     template<class Executor, class Function, class Future, class Factory1, class Factory2>
     executor_future_t<Executor,std::invoke_result_t<Factory1>>
-    bulk_then_execute(const Executor& exec, Function f, executor_shape_t<Executor> shape,
+    bulk_twoway_then_possibly_blocking_execute(const Executor& exec, Function f, executor_shape_t<Executor> shape,
                       Future& predecessor_future,
                       Factory1 result_factory, Factory2 shared_factory);
 
@@ -785,24 +781,24 @@ executor's provided functionality. For example, a requirement for never-blocking
 execution from an executor which always executes "inline".
 
 As a simple example, consider the adaptation performed by
-`execution::sync_execute` when a given executor provides no native support:
+`execution::twoway_always_blocking_execute` when a given executor provides no native support:
 
     template<class Executor, class Function>
     executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>>>
-    sync_execute(const Executor& exec, Function&& f)
+    twoway_always_blocking_execute(const Executor& exec, Function&& f)
     {
-      auto future = execution::async_execute(exec, std::forward<Function>(f));
+      auto future = execution::twoway_possibly_blocking_execute(exec, std::forward<Function>(f));
       future.wait();
       return future;
     }
 
-In this case, `execution::sync_execute` creates asynchronous execution via
-`execution::async_execute` and receives a future object, which is immediately
+In this case, `execution::twoway_always_blocking_execute` creates asynchronous execution via
+`execution::twoway_possibly_blocking_execute` and receives a future object, which is immediately
 waited on. Even though `exec` does not provide a native version of
-`sync_execute`, its client may use it as if it does.
+`twoway_always_blocking_execute`, its client may use it as if it does.
 
 **Predicting adaptations.** Other customization points may apply more complex
-adaptations than the simple one applied by `sync_execute`. Indeed, there may be
+adaptations than the simple one applied by `twoway_always_blocking_execute`. Indeed, there may be
 a variety of ways to adapt a particular executor given the native interactions
 it offers. Some of these adaptations imply greater costs than others. Our
 proposal specifies these adaptations in detail and provides compile-time tools
@@ -813,7 +809,7 @@ point.
 For example in order to predict whether the above adaptation is possible the type
 trait to query the executor:
 
-    template<class T> struct can_sync_execute;
+    template<class T> struct can_twoway_always_blocking_execute;
 
 **Invariant preservation.** There are limits to the kinds of adaptations that
 customization points may apply, and these limits preserve executor invariants.
@@ -830,7 +826,7 @@ behavior when adapting an executor's native functionality. During adaptation,
          customization point never weakens the group execution ordering
          guarantee provided by a bulk executor.
 
-[^invariant_caveat]: Except in the case of `sync_execute`, as previously mentioned. 
+[^invariant_caveat]: Except in the case of `twoway_always_blocking_execute`, as previously mentioned.
 
 # Implementing Executors
 
@@ -852,7 +848,7 @@ executor which always creates execution "inline":
       }
 
       template<class Function>
-      auto sync_execute(Function&& f) const {
+      auto twoway_always_blocking_execute(Function&& f) const {
         using result_type = std::invoke_result_t<Function>;
         return make_ready_future<result_type>(std::forward<Function>(f)());
       }
@@ -873,7 +869,7 @@ through executor-specific type traits.
 **Executor identity.** All executors are required to be `EqualityComparable` in
 order for clients to reason about their identity. If two executors are
 equivalent, then they may be used interchangably to produce the same side
-effects. For example, because `inline_executor::sync_execute` simply invokes
+effects. For example, because `inline_executor::twoway_always_blocking_execute` simply invokes
 its function inline, all instances of `inline_executor` produce the same side
 effects and are therefore equivalent.
 
@@ -909,7 +905,7 @@ make choices about where to create execution agents. In generic programming
 contexts such as templates the concrete type of execution context will not be
 known. However, the programmer may still manipulate execution contexts
 semi-generically through specializations which apply to concrete contexts.
-    
+
 Recall `inline_executor`. Because it is such a simple executor, it serves as
 its own execution context. Its `.context()` function simply returns a reference
 to itself. In general, more sophisticated executors will return some other
@@ -935,7 +931,7 @@ object. Consider a `thread_pool_executor`:
         }
 
         template<class Function>
-        void execute(Function&& f) const {
+        void possibly_blocking_execute(Function&& f) const {
           pool_.submit(std::forward<Function>(f));
         }
     };
@@ -1002,7 +998,7 @@ returns one of three values:
   3. `never_blocking_execution`: The agents' execution does not block the client.
 
 The guarantee provided by `executor_execute_blocking_guarantee` only applies to
-those customization points whose name is suffixed with `execute`. Exceptions
+those customization points whose name is suffixed with `possibly_blocking_execute`. Exceptions
 are the `sync_` customization points, which must always block their client by
 definition. When the agents created by an executor possibly block its client,
   it's conceivable that the executor could provide dynamic runtime facilities
@@ -1062,7 +1058,7 @@ executor's execution context by decaying the result of its member function
 **Associated `Future` type.** `executor_future` names the type of an executor's
 associated future type, which is the type of object returned by asynchronous,
            two-way customization points. The type is determined by the result
-           of `execution::async_execute`, which must satisfy the requirements
+           of `execution::twoway_possibly_blocking_execute`, which must satisfy the requirements
            of the `Future` concept[^future_footnote]. Otherwise, the type is
            `std::future`. All of an executor's two-way asynchronous
            customization points must return the same type of future.
@@ -1096,18 +1092,17 @@ We begin by discussing the execution functions which create groups of execution
 agents in bulk, because the corresponding single-agent functions are each a
 functionally special case.
 
-### `bulk_then_execute`
+### `bulk_twoway_then_possibly_blocking_execute`
 
     template<class Executor, class Future, class Function, class ResultFactory,
              class SharedFactory>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>,
                      decltype(std::declval<Future>().get())&>>
-    bulk_then_execute(const Executor& exec, Function&& func, Future& pred,
-                      executor_shape_t<Executor> shape,
-                      ResultFactory result_factory,
-                      SharedFactory shared_factory);
+    bulk_twoway_then_possibly_blocking_execute(const Executor& exec,
+      Function&& func, Future& pred, executor_shape_t<Executor> shape,
+      ResultFactory result_factory, SharedFactory shared_factory);
 
-`bulk_then_execute` asynchronously creates a group of execution agents of shape
+`bulk_twoway_then_possibly_blocking_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution begins after the completion of `pred` and returns a future that
@@ -1116,10 +1111,10 @@ can be used to wait for execution to complete containing the result of
 `std::forward<Function>(func)(i, r, s)`, where `i` is of type
 `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
-`bulk_then_execute` may or may not the caller until execution completes,
+`bulk_twoway_then_possibly_blocking_execute` may or may not the caller until execution completes,
 depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
-`bulk_then_execute` is the most general execution function we have identified
+`bulk_twoway_then_possibly_blocking_execute` is the most general execution function we have identified
 because it may be used to implement any other execution function without having
 to go out-of-band through channels not made explicit through the execution
 function's interface. Explicitly elaborating this information through the
@@ -1128,35 +1123,34 @@ optimizations which would not be possible had that information been discarded
 through backchannels.
 
 For example, suppose the only available execution function was
-`bulk_sync_execute`. It would be possible to implement `bulk_then_execute`'s
-functionality by making a call to `bulk_sync_execute` inside a continuation
+`bulk_twoway_always_blocking_execute`. It would be possible to implement `bulk_twoway_then_possibly_blocking_execute`'s
+functionality by making a call to `bulk_twoway_always_blocking_execute` inside a continuation
 created by `predecessor_future.then`:
 
     predecessor_future.then([=] {
-      return exec.bulk_sync_execute(exec, f, shape, result_factory, shared_factory).get();
+      return exec.bulk_twoway_always_blocking_execute(exec, f, shape, result_factory, shared_factory).get();
     });
 
 Note that this implementation creates `1 + shape` execution agents: one agent
-created by `then` along with `shape` agents created by `bulk_sync_execute`.
+created by `then` along with `shape` agents created by `bulk_twoway_always_blocking_execute`.
 Depending on the relative cost of agents created by `then` and
-`bulk_sync_execute`, the overhead of introducing that extra agent may be
+`bulk_twoway_always_blocking_execute`, the overhead of introducing that extra agent may be
 significant. Moreover, because the `then` operation occurs separately from
-`bulk_sync_execute`, the continuation is invisible to `exec` and this precludes
+`bulk_twoway_always_blocking_execute`, the continuation is invisible to `exec` and this precludes
 `exec`'s participation in scheduling. Because we wish to allow executors to
 abstract sophisticated task-scheduling runtimes, this shortcoming is
 unacceptable.
 
-### `bulk_async_execute`
+### `bulk_twoway_possibly_blocking_execute`
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
-    bulk_async_execute(const Executor& exec, Function&& func,
-                       executor_shape_t<Executor> shape,
-                       ResultFactory result_factory,
-                       SharedFactory shared_factory);
+    bulk_twoway_possibly_blocking_execute(const Executor& exec, Function&& func,
+      executor_shape_t<Executor> shape, ResultFactory result_factory,
+      SharedFactory shared_factory);
 
-`bulk_async_execute` asynchronously creates a group of execution agents of shape
+`bulk_twoway_possibly_blocking_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and returns a future that can be used to
@@ -1164,22 +1158,22 @@ wait for execution to complete containing the result of `result_factory`. Each
 created execution agent calls `std::forward<Function>(func)(i, r, s)`, where
 `i` is of type `executor_index_t<Executor>`, `r` is a function object returned
 from `return_factory` and `s` is a shared object returned from `shared_factory`.
-`bulk_async_execute` may or may not block the caller until execution completes,
+`bulk_twoway_possibly_blocking_execute` may or may not block the caller until execution completes,
 depending on the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
 
-Like `bulk_then_execute`, `bulk_async_execute`
+Like `bulk_twoway_then_possibly_blocking_execute`, `bulk_twoway_possibly_blocking_execute`
 returns a future corresponding to the result of the asynchronous group of
-execution agents it creates. Due to these similarities, `bulk_async_execute` is
-functionally equivalent to calling `bulk_then_execute` with a ready `void`
+execution agents it creates. Due to these similarities, `bulk_twoway_possibly_blocking_execute` is
+functionally equivalent to calling `bulk_twoway_then_possibly_blocking_execute` with a ready `void`
 future:
 
     future<void> no_predecessor = make_ready_future();
-    exec.bulk_then_execute(func, shape, no_predecessor, result_factory,
+    exec.bulk_twoway_then_possibly_blocking_execute(func, shape, no_predecessor, result_factory,
                            shared_factory);
 
-We include `bulk_async_execute` because the equivalent path through
-`bulk_then_execute` via a ready future may incur overhead. The cost of the
+We include `bulk_twoway_possibly_blocking_execute` because the equivalent path through
+`bulk_twoway_then_possibly_blocking_execute` via a ready future may incur overhead. The cost of the
 future itself may be significant, especially if any sort of
 dynamically-allocated asynchronous state is associated with that future.
 Alternatively, the act of scheduling itself may be a source of overhead,
@@ -1188,21 +1182,20 @@ runtime. Providing executors the opportunity to specialize for cases where
 it is known at compile time that no dependency exists avoids both hazards.
 
 Moreover, common types of executor may not naturally create execution in terms
-of continuations on futures as expected by `bulk_then_execute`.
-`bulk_async_execute` is a better match for these cases because it does not
+of continuations on futures as expected by `bulk_twoway_then_possibly_blocking_execute`.
+`bulk_twoway_possibly_blocking_execute` is a better match for these cases because it does not
 require accommodating a predecessor dependency.
 
-### `bulk_async_post`
+### `bulk_twoway_never_blocking_execute`
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
-    bulk_async_post(const Executor& exec, Function&& func,
-                    executor_shape_t<Executor> shape,
-                    ResultFactory result_factory,
-                    SharedFactory shared_factory);
+    bulk_twoway_never_blocking_execute(const Executor& exec, Function&& func,
+      executor_shape_t<Executor> shape, ResultFactory result_factory,
+      SharedFactory shared_factory);
 
-`bulk_async_post` asynchronously creates a group of execution agents of shape
+`bulk_twoway_never_blocking_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and returns a future that can be used to
@@ -1210,28 +1203,27 @@ wait for execution to complete containing the result of `result_factory`. Each
 created execution agent calls `std::forward<Function>(func)(i, r, s)`, where
 `i` is of type `executor_index_t<Executor>`, `r` is a function object returned
 from `return_factory` and `s` is a shared object returned from
-`shared_factory`. `bulk_async_post` does not block the caller, regardless of
+`shared_factory`. `bulk_twoway_never_blocking_execute` does not block the caller, regardless of
 the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
-`bulk_async_post` is equivalent to `bulk_async_execute` except that it makes an
+`bulk_twoway_never_blocking_execute` is equivalent to `bulk_twoway_possibly_blocking_execute` except that it makes an
 additional guarantee not to block the client's execution. Some executors will
 not be able to provide such a guarantee and could not be adapted to this
-functionality when `bulk_async_post` is absent. For example, an implementation
-of `bulk_async_post` which simply forwards its arguments directly to
-`bulk_async_execute` is possible only if
+functionality when `bulk_twoway_never_blocking_execute` is absent. For example, an implementation
+of `bulk_twoway_never_blocking_execute` which simply forwards its arguments directly to
+`bulk_twoway_possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
-### `bulk_async_defer`
+### `bulk_twoway_never_blocking_continuation_execute`
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
     executor_future_t<std::invoke_result_t<std::decay_t<ResultFactory>>>
-    bulk_async_defer(const Executor& exec, Function&& func,
-                     executor_shape_t<Executor> shape,
-                     ResultFactory result_factory,
-                     SharedFactory shared_factory);
+    bulk_twoway_never_blocking_continuation_execute(const Executor& exec,
+      Function&& func, executor_shape_t<Executor> shape, ResultFactory result_factory,
+      SharedFactory shared_factory);
 
-`bulk_async_defer` asynchronously creates a group of execution agents of shape
+`bulk_twoway_never_blocking_continuation_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and returns a future that can be used to
@@ -1239,33 +1231,32 @@ wait for execution to complete containing the result of `result_factory`. Each
 created execution agent calls `std::forward<Function>(func)(i, r, s)`, where `i`
 is of type `executor_index_t<Executor>`, `r` is a function object returned from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
-`bulk_async_defer` does not block the caller,
+`bulk_twoway_never_blocking_continuation_execute` does not block the caller,
 regardless of the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
-`bulk_async_defer` is equivalent to `bulk_async_execute` except that it makes an
+`bulk_twoway_never_blocking_continuation_execute` is equivalent to `bulk_twoway_possibly_blocking_execute` except that it makes an
 additional guarantee not to block the client's execution. Some executors will
 not be able to provide such a guarantee and could not be adapted to this
-functionality when `bulk_async_defer` is absent. For example, an implementation
-of `bulk_async_defer` which simply forwards its arguments directly to
-`bulk_async_execute` is possible only if
+functionality when `bulk_twoway_never_blocking_continuation_execute` is absent. For example, an implementation
+of `bulk_twoway_never_blocking_continuation_execute` which simply forwards its arguments directly to
+`bulk_twoway_possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
-**Comparison to bulk_async_post.** The behavior of `bulk_async_defer` is
-semantically equivalent to `bulk_async_post` and is primarily to indicate an
+**Comparison to bulk_twoway_never_blocking_execute.** The behavior of `bulk_twoway_never_blocking_continuation_execute` is
+semantically equivalent to `bulk_twoway_never_blocking_execute` and is primarily to indicate an
 ordering of work which allows for additional performance optimizations within
 the executor implementation.
 
-### `bulk_sync_execute`
+### `bulk_twoway_always_blocking_execute`
 
     template<class Executor, class Function, class ResultFactory,
              class SharedFactory>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<ResultFactory>>>
-    bulk_sync_execute(const Executor& exec, Function&& func,
-                      executor_shape_t<Executor> shape,
-                      ResultFactory result_factory,
-                      SharedFactory shared_factory);
+    bulk_twoway_always_blocking_execute(const Executor& exec, Function&& func,
+      executor_shape_t<Executor> shape, ResultFactory result_factory,
+      SharedFactory shared_factory);
 
-`bulk_sync_execute` asynchronously creates a group of execution agents of shape
+`bulk_twoway_always_blocking_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and returns the result of
@@ -1273,18 +1264,18 @@ whose execution may begin immediately and returns the result of
 `std::forward<Function>(func)(i, r, s)`, where `i` is of type
 `executor_index_t<Executor>`, `r` is a function object retured from
 `return_factory` and `s` is a shared object returned from `shared_factory`.
-`bulk_sync_execute` always blocks the caller until execution completes,
+`bulk_twoway_always_blocking_execute` always blocks the caller until execution completes,
 regardless of the value of `executor_execute_blocking_guarantee_t<Executor>`.
 
-`bulk_sync_execute` is equivalent to `bulk_async_execute` except that it blocks
+`bulk_twoway_always_blocking_execute` is equivalent to `bulk_twoway_possibly_blocking_execute` except that it blocks
 its client until the result of execution is complete. Correspondingly, it may
-be implemented by calling `bulk_async_execute` and waiting on the resulting future:
+be implemented by calling `bulk_twoway_possibly_blocking_execute` and waiting on the resulting future:
 
-    auto future = exec.bulk_async_execute(f, shape, result_factory, shared_factory);
+    auto future = exec.bulk_twoway_possibly_blocking_execute(f, shape, result_factory, shared_factory);
     future.wait();
     return future;
 
-We include `bulk_sync_execute` to avoid overhead incurred by introducing
+We include `bulk_twoway_always_blocking_execute` to avoid overhead incurred by introducing
 unnecessary asynchrony. This overhead is likely to be significant for executors
 whose cost of execution agent creation is very small. A hypothetical
 `simd_executor` or `inline_executor` are examples.
@@ -1322,26 +1313,26 @@ lose the ability to perform a compile time test to determine whether an
 executor "natively" supports single-agent execution (e.g. the
 `has_executor_member` trait included in this proposal).
 
-### `then_execute`
+### `twoway_then_possibly_blocking_execute`
 
     template<class Executor, class Function, class Future,
              class Allocator = std::allocator<void>>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>,
                       decltype(std::declval<Future>().get())&>>
-    then_execute(const Executor& exec, Function&& func, Future& pred,
-                 Allocator& alloc = Allocator());
+    twoway_then_possibly_blocking_execute(const Executor& exec, Function&& func,
+      Future& pred, Allocator& alloc = Allocator());
 
-`then_execute` asynchronously creates a single execution agent bound to the
+`twoway_then_possibly_blocking_execute` asynchronously creates a single execution agent bound to the
 executor `exec` whose execution begins after the completion of `pred` and
 returns a future that can be used to wait for execution to complete containing
 the result of `func`. The created execution agent calls
-`std::forward<Function>(func)()`. `then_execute` may or may not the caller until
+`std::forward<Function>(func)()`. `twoway_then_possibly_blocking_execute` may or may not the caller until
 execution completes, depending on the value of
 `executor_execute_blocking_guarantee_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
-`then_execute` creates an asynchronous execution agent. It may be implemented
-by using `bulk_then_execute` to create a group with a single agent:
+`twoway_then_possibly_blocking_execute` creates an asynchronous execution agent. It may be implemented
+by using `bulk_twoway_then_possibly_blocking_execute` to create a group with a single agent:
 
     using result_t = std::invoke_result_t<Function>;
     using predecessor_t = decltype(predecessor_future.get());
@@ -1364,7 +1355,7 @@ by using `bulk_then_execute` to create a group with a single agent:
       result = func(predecessor);
     };
 
-    return exec.bulk_then_execute(g,
+    return exec.bulk_twoway_then_possibly_blocking_execute(g,
       executor_shape_t<Executor>{1}, // create a single agent group
       pred,
       result_factory,
@@ -1373,33 +1364,33 @@ by using `bulk_then_execute` to create a group with a single agent:
 
 The sample implementation passes both the function to invoke and its result
 indirectly via factories. The result of these factories are shared across the
-group of agents created by `bulk_then_execute`. However, this group has only
+group of agents created by `bulk_twoway_then_possibly_blocking_execute`. However, this group has only
 one agent and no sharing actually occurs. The cost of this unnecessary sharing
-may be significant and can be avoided if an executor specializes `then_execute`.
+may be significant and can be avoided if an executor specializes `twoway_then_possibly_blocking_execute`.
 
-### `async_execute`
+### `twoway_possibly_blocking_execute`
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
-    async_execute(const Executor& exec, Function&& func,
-                  Allocator& alloc = Allocator());
+    twoway_possibly_blocking_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`async_execute` asynchronously creates a single execution agent bound to the
+`twoway_possibly_blocking_execute` asynchronously creates a single execution agent bound to the
 executor `exec` whose execution may begin immediately and returns a future that
 can be used to wait for execution to complete containing the result of `func`.
 The created execution agent calls `std::forward<Function>(func)()`.
-`async_execute` may or may not the caller until execution completes, depending
+`twoway_possibly_blocking_execute` may or may not the caller until execution completes, depending
 on the value of `executor_execute_blocking_guarantee_t<Executor>`. The allocator
 `alloc` can be used to allocate memory for `func`.
 
-`async_execute`  may be implemented by using `then_execute` with a ready `void` future:
+`twoway_possibly_blocking_execute`  may be implemented by using `twoway_then_possibly_blocking_execute` with a ready `void` future:
 
     std::experimental::future<void> ready_future = std::experimental::make_ready_future();
-    return exec.then_execute(std::forward<Function>(f), ready_future);
+    return exec.twoway_then_possibly_blocking_execute(std::forward<Function>(f), ready_future);
 
-Alternatively, `bulk_async_execute` could be used, analogously to the use of
-`bulk_then_execute` in `then_execute`'s implementation.
+Alternatively, `bulk_twoway_possibly_blocking_execute` could be used, analogously to the use of
+`bulk_twoway_then_possibly_blocking_execute` in `twoway_then_possibly_blocking_execute`'s implementation.
 
 The cost of a superfluous immediately-ready future object could be significant
 compared to the cost of agent creation. For example, the future object's
@@ -1413,99 +1404,99 @@ hypothetical `always_ready_future` could be an efficient substitute as it would
 not require addressing the problem of synchronization:
 
     always_ready_future<void> ready_future;
-    return exec.then_execute(std::forward<Function>(f), ready_future);
+    return exec.twoway_then_possibly_blocking_execute(std::forward<Function>(f), ready_future);
 
-However, to fully exploit such efficiency, `then_execute` may need to
+However, to fully exploit such efficiency, `twoway_then_possibly_blocking_execute` may need to
 recognize this case and take special action for `always_ready_future`.
 
 Because of the opportunity for efficient specialization of a common use case, and to avoid
-requiring executors to explicitly support continuations with `then_execute`, including
-`async_execute` as an execution function is worthwhile.
+requiring executors to explicitly support continuations with `twoway_then_possibly_blocking_execute`, including
+`twoway_possibly_blocking_execute` as an execution function is worthwhile.
 
-### `async_post`
-
-    template<class Executor, class Function,
-             class Allocator = std::allocator<void>>
-    executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
-    async_post(const Executor& exec, Function&& func,
-               Allocator& alloc = Allocator());
-
-`async_post` asynchronously creates a single execution agent bound to the
-executor `exec` whose execution may begin immediately and returns a future that
-can be used to wait for execution to complete containing the result of `func`.
-The created execution agent calls `std::forward<Function>(func)()`.
-`async_post` does not block the caller, regardless of the value of
-`executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
-used to allocate memory for `func`.
-
-`async_post` is equivalent to `async_execute` except that it makes an
-additional guarantee not to block the client's execution. Some executors will
-not be able to provide such a guarantee and could not be adapted to this
-functionality when `async_post` is absent. For example, an implementation of
-`async_post` which simply forwards its arguments directly to `async_post` is
-possible only if `executor_execute_blocking_guarantee_t<Executor>` is
-`never_blocking_execution`.
-
-### `async_defer`
+### `twoway_never_blocking_execute`
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
     executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
-    async_defer(const Executor& exec, Function&& func,
-                Allocator& alloc = Allocator());
+    twoway_never_blocking_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`async_defer` asynchronously creates a single execution agent bound to the
+`twoway_never_blocking_execute` asynchronously creates a single execution agent bound to the
 executor `exec` whose execution may begin immediately and returns a future that
 can be used to wait for execution to complete containing the result of `func`.
 The created execution agent calls `std::forward<Function>(func)()`.
-`async_defer` does not block the caller, regardless of the value of
+`twoway_never_blocking_execute` does not block the caller, regardless of the value of
 `executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
-`async_defer` is equivalent to `async_execute` except that it makes an
+`twoway_never_blocking_execute` is equivalent to `twoway_possibly_blocking_execute` except that it makes an
 additional guarantee not to block the client's execution. Some executors will
 not be able to provide such a guarantee and could not be adapted to this
-functionality when `async_defer` is absent. For example, an implementation of
-`async_defer` which simply forwards its arguments directly to `async_defer` is
+functionality when `twoway_never_blocking_execute` is absent. For example, an implementation of
+`twoway_never_blocking_execute` which simply forwards its arguments directly to `twoway_never_blocking_execute` is
 possible only if `executor_execute_blocking_guarantee_t<Executor>` is
 `never_blocking_execution`.
 
-**Comparison to async_post.** `async_defer`'s semantics are identical to
-`async_post`. That is, they may be used interchangeably without effecting a
-program's correctness. `async_defer` indicates that `func` represents a
+### `twoway_never_blocking_continuation_execute`
+
+    template<class Executor, class Function,
+             class Allocator = std::allocator<void>>
+    executor_future_t<Executor, std::invoke_result_t<std::decay_t<Function>>>
+    twoway_never_blocking_continuation_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
+
+`twoway_never_blocking_continuation_execute` asynchronously creates a single execution agent bound to the
+executor `exec` whose execution may begin immediately and returns a future that
+can be used to wait for execution to complete containing the result of `func`.
+The created execution agent calls `std::forward<Function>(func)()`.
+`twoway_never_blocking_continuation_execute` does not block the caller, regardless of the value of
+`executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
+used to allocate memory for `func`.
+
+`twoway_never_blocking_continuation_execute` is equivalent to `twoway_possibly_blocking_execute` except that it makes an
+additional guarantee not to block the client's execution. Some executors will
+not be able to provide such a guarantee and could not be adapted to this
+functionality when `twoway_never_blocking_continuation_execute` is absent. For example, an implementation of
+`twoway_never_blocking_continuation_execute` which simply forwards its arguments directly to `twoway_never_blocking_continuation_execute` is
+possible only if `executor_execute_blocking_guarantee_t<Executor>` is
+`never_blocking_execution`.
+
+**Comparison to twoway_never_blocking_execute.** `twoway_never_blocking_continuation_execute`'s semantics are identical to
+`twoway_never_blocking_execute`. That is, they may be used interchangeably without effecting a
+program's correctness. `twoway_never_blocking_continuation_execute` indicates that `func` represents a
 continuation of the caller which allows for additional performance
 optimizations within the executor implementation.
 
-### `sync_execute`
+### `twoway_always_blocking_execute`
 
     template<class Executor, class Function,
              class Allocator = std::allocator<void>>
     executor_future_t<Executor,std::invoke_result_t<std::decay_t<Function>>>
-    sync_execute(const Executor& exec, Function&& func,
-                 Allocator& alloc = Allocator());
+    twoway_always_blocking_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`sync_execute` asynchronously creates a single execution agent bound to the
+`twoway_always_blocking_execute` asynchronously creates a single execution agent bound to the
 executor `exec` whose execution may begin immediately and returns the result of
 `func`. The created execution agent calls `std::forward<Function>(func)()`.
-`sync_execute` blocks the caller until execution completes. The allocator
+`twoway_always_blocking_execute` blocks the caller until execution completes. The allocator
 `alloc` can be used to allocate memory for `func`.
 
-`sync_execute` is equivalent to `async_execute` except that it blocks its
-client until the result of execution is complete. 
-Correspondingly, it may be implemented by calling `async_execute` and waiting on the resulting future:
+`twoway_always_blocking_execute` is equivalent to `twoway_possibly_blocking_execute` except that it blocks its
+client until the result of execution is complete.
+Correspondingly, it may be implemented by calling `twoway_possibly_blocking_execute` and waiting on the resulting future:
 
-    auto future = exec.async_execute(std::forward<Function>(f));
+    auto future = exec.twoway_possibly_blocking_execute(std::forward<Function>(f));
     future.wait();
     return future;
 
-We include `sync_execute` to avoid overhead incurred by introducing unnecessary
+We include `twoway_always_blocking_execute` to avoid overhead incurred by introducing unnecessary
 asynchrony. This overhead is likely to be significant for executors whose cost
 of execution agent creation is very small. A hypothetical `simd_executor` or
 `inline_executor` are examples.
 
 We believe it is possible to make the cost of the future arbitrarily small in
 very special cases. For example, if the executor's associated future is a
-hypothetical `always_ready_future`, then a path through `async_execute` is
+hypothetical `always_ready_future`, then a path through `twoway_possibly_blocking_execute` is
 unlikely to incur any penalty:
 
     template<class T>
@@ -1522,93 +1513,91 @@ unlikely to incur any penalty:
     ...
 
     using result_type = std::invoke_result_t<std::decay_t<Function>>;
-    always_ready_future<result_type> future = exec.async_execute(std::forward<Function>(f));
+    always_ready_future<result_type> future = exec.twoway_possibly_blocking_execute(std::forward<Function>(f));
 
 However, this efficient implementation depends on `always_ready_future` being
 the executor's associated future type. Moreover, it requires the executor to
-treat `async_execute` as `sync_execute`'s moral equivalent by returning an
+treat `twoway_possibly_blocking_execute` as `twoway_always_blocking_execute`'s moral equivalent by returning an
 immediately ready result which always blocks the client.
 
 Because most executors will not return ready future objects from their two-way
 asynchronous execution functions, they will incur the overhead of this
-`async_execute`-based implementation. Therefore, `sync_execute` is worth
+`twoway_possibly_blocking_execute`-based implementation. Therefore, `twoway_always_blocking_execute` is worth
 including.
 
 ## One-Way Bulk-Agent Functions
 
-### `bulk_post`
+### `bulk_never_blocking_execute`
 
     template<class Executor, class Function, class SharedFactory>
-    void bulk_post(const Executor& exec, Function&& func,
-                   executor_shape_t<Executor> shape,
-                   SharedFactory shared_factory);
+    void bulk_never_blocking_execute(const Executor& exec, Function&& func,
+      executor_shape_t<Executor> shape, SharedFactory shared_factory);
 
-`bulk_post` asynchronously creates a group of execution agents of shape `shape`
+`bulk_never_blocking_execute` asynchronously creates a group of execution agents of shape `shape`
 with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and does not return a value. Each created
 execution agent calls `std::forward<Function>(func)(i, s)`, where `i` is of
 type `executor_index_t<Executor>` and `s` is a shared object returned from
-`shared_factory`. `bulk_post` does not block the caller, regardless of the
+`shared_factory`. `bulk_never_blocking_execute` does not block the caller, regardless of the
 value of `executor_execute_blocking_category_t<Executor>`.
 
-`bulk_post` is equivalent to `bulk_execute` except that it makes an additional
+`bulk_never_blocking_execute` is equivalent to `bulk_possibly_blocking_execute` except that it makes an additional
 guarantee not to block the client's execution. Some executors will not be able
 to provide such a guarantee and could not be adapted to this functionality when
-`bulk_post` is absent. For example, an implementation of `bulk_post` which
-simply forwards its arguments directly to `bulk_execute` is possible only if
+`bulk_never_blocking_execute` is absent. For example, an implementation of `bulk_never_blocking_execute` which
+simply forwards its arguments directly to `bulk_possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is
 `never_blocking_execution`.
 
-### `bulk_defer`
+### `bulk_never_blocking_continuation_execute`
 
     template<class Executor, class Function, class SharedFactory>
-    void bulk_defer(const Executor& exec, Function&& func,
-                    executor_shape_t<Executor> shape,
-                    SharedFactory shared_factory);
+    void bulk_never_blocking_continuation_execute(const Executor& exec,
+      Function&& func, executor_shape_t<Executor> shape,
+      SharedFactory shared_factory);
 
 
-`bulk_defer` asynchronously creates a group of execution agents of shape
+`bulk_never_blocking_continuation_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and does not return a value. Each created
 execution agent calls `std::forward<Function>(func)(i, s)`, where `i` is of
 type `executor_index_t<Executor>` and `s` is a shared object returned from
-`shared_factory`. `bulk_defer` does not block the caller, regardless of the
+`shared_factory`. `bulk_never_blocking_continuation_execute` does not block the caller, regardless of the
 value of `executor_execute_blocking_category_t<Executor>`.
 
-`bulk_defer` is equivalent to `bulk_execute` except that it makes an additional
+`bulk_never_blocking_continuation_execute` is equivalent to `bulk_possibly_blocking_execute` except that it makes an additional
 guarantee not to block the client's execution. Some executors will not be able
 to provide such a guarantee and could not be adapted to this functionality when
-`bulk_defer` is absent. For example, an implementation of `bulk_defer` which
-simply forwards its arguments directly to `bulk_execute` is possible only if
+`bulk_never_blocking_continuation_execute` is absent. For example, an implementation of `bulk_never_blocking_continuation_execute` which
+simply forwards its arguments directly to `bulk_possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is
 `never_blocking_execution`.
 
-**Comparison to bulk_post.** `bulk_defer`'s semantics are identical to
-`bulk_post`. That is, they may be used interchangeably without effecting a
-program's correctness. `bulk_defer` indicates that `func` represents a bulk
+**Comparison to bulk_never_blocking_execute.** `bulk_never_blocking_continuation_execute`'s semantics are identical to
+`bulk_never_blocking_execute`. That is, they may be used interchangeably without effecting a
+program's correctness. `bulk_never_blocking_continuation_execute` indicates that `func` represents a bulk
 continuation of the caller which allows for additional performance
 optimizations within the executor implementation.
 
-### `bulk_execute`
+### `bulk_possibly_blocking_execute`
 
     template<class Executor, class Function, class SharedFactory>
-    void bulk_execute(const Executor& exec, Function&& func,
-                      executor_shape_t<Executor> shape,
-                      SharedFactory shared_factory);
+    void bulk_possibly_blocking_execute(const Executor& exec, Function&& func,
+      executor_shape_t<Executor> shape, SharedFactory shared_factory);
 
-`bulk_execute` asynchronously creates a group of execution agents of shape
+`bulk_possibly_blocking_execute` asynchronously creates a group of execution agents of shape
 `shape` with forward progress guarantees of
 `executor_execution_mapping_guarantee_t<Executor>`, bound to the executor `exec`
 whose execution may begin immediately and does not return a value. Each created
 execution agent calls `std::forward<Function>(func)(i, s)`, where `i` is of type
 `executor_index_t<Executor>` and `s` is a shared object returned from
-`shared_factory`. `bulk_execute` may or may not the caller until execution
+`shared_factory`. `bulk_possibly_blocking_execute` may or may not the caller until execution
 completes, depending on the value of
 `executor_execute_blocking_guarantee_t<Executor>`.
 
-`bulk_execute` is equivalent to `execute` except that it creates a single
+`bulk_possibly_blocking_execute` is equivalent to `possibly_blocking_execute` except that it creates a single
 execution agent rather than a group of execution agents.
 
     // create shared object
@@ -1620,81 +1609,84 @@ execution agent rather than a group of execution agents.
         // construct index
         executor_shape_t<Executor> index{i};
 
-        // create a lambda for the function for `execute`
+        // create a lambda for the function for `possibly_blocking_execute`
         auto g = [=, &shared](Function& func) {
           func(index, shared);
         };
 
-        exec.execute(g);
+        exec.possibly_blocking_execute(g);
     }
 
-We include `bulk_execute` because the equivalent path through `execute` via a
+We include `bulk_possibly_blocking_execute` because the equivalent path through `possibly_blocking_execute` via a
 for loop at the point of submission would incur overhead and would not be able
 to guarantee correct forward progress guarantees between each execution agent
-created by `execute`.
+created by `possibly_blocking_execute`.
 
 ## One-Way Single-Agent Functions
 
-### `post`
+### `never_blocking_execute`
 
     template<class Executor, class Function, class Allocator = std::allocator<void>>
-    void post(const Executor& exec, Function&& func, Allocator& alloc = Allocator());
+    void never_blocking_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`post` asynchronously creates a single execution agent bound to the executor
+`never_blocking_execute` asynchronously creates a single execution agent bound to the executor
 `exec` whose execution may begin immediately and does not return a value. The
-created execution agent calls `std::forward<Function>(func)()`. `post` does not
+created execution agent calls `std::forward<Function>(func)()`. `never_blocking_execute` does not
 block the caller, regardless of the value of
 `executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
-`post` is equivalent to `execute` except that it makes an additional guarantee
+`never_blocking_execute` is equivalent to `possibly_blocking_execute` except that it makes an additional guarantee
 not to block the client's execution. Some executors will not be able to provide
-such a guarantee and could not be adapted to this functionality when `post` is
-absent. For example, an implementation of `post` which simply forwards its
-arguments directly to `execute` is possible only if
+such a guarantee and could not be adapted to this functionality when `never_blocking_execute` is
+absent. For example, an implementation of `never_blocking_execute` which simply forwards its
+arguments directly to `possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
-### `defer`
+### `never_blocking_continuation_execute`
 
     template<class Executor, class Function, class Allocator = std::allocator<void>>
-    void defer(const Executor& exec, Function&& func, Allocator& alloc = Allocator());
+    void never_blocking_continuation_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`defer` asynchronously creates a single execution agent bound to the executor
+`never_blocking_continuation_execute` asynchronously creates a single execution agent bound to the executor
 `exec` whose execution may begin immediately and does not return a value. The
-created execution agent calls `std::forward<Function>(func)()`. `defer` does
+created execution agent calls `std::forward<Function>(func)()`. `never_blocking_continuation_execute` does
 not block the caller, regardless of the value of
 `executor_execute_blocking_category_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
-`defer` is equivalent to `execute` except that it makes an additional guarantee
+`never_blocking_continuation_execute` is equivalent to `possibly_blocking_execute` except that it makes an additional guarantee
 not to block the client's execution. Some executors will not be able to provide
-such a guarantee and could not be adapted to this functionality when `defer` is
-absent. For example, an implementation of `defer` which simply forwards its
-arguments directly to `execute` is possible only if
+such a guarantee and could not be adapted to this functionality when `never_blocking_continuation_execute` is
+absent. For example, an implementation of `never_blocking_continuation_execute` which simply forwards its
+arguments directly to `possibly_blocking_execute` is possible only if
 `executor_execute_blocking_guarantee_t<Executor>` is `never_blocking_execution`.
 
-**Comparison to post.** `defer`'s semantics are identical to `post`. That is,
+**Comparison to never_blocking_execute.** `never_blocking_continuation_execute`'s semantics are identical to `never_blocking_execute`. That is,
 they may be used interchangeably without effecting a program's correctness.
-`defer` indicates that `func` represents a continuation of the caller which
+`never_blocking_continuation_execute` indicates that `func` represents a continuation of the caller which
 allows for additional performance optimizations within the executor
 implementation.
 
-### `execute`
+### `possibly_blocking_execute`
 
     template<class Executor, class Function, class Allocator = std::allocator<void>>
-    void execute(const Executor& exec, Function&& func, Allocator& alloc = Allocator());
+    void possibly_blocking_execute(const Executor& exec, Function&& func,
+      Allocator& alloc = Allocator());
 
-`execute` asynchronously creates a single execution agent bound to the executor
+`possibly_blocking_execute` asynchronously creates a single execution agent bound to the executor
 `exec` whose execution may begin immediately and does not return a value. The
-created execution agent calls `std::forward<Function>(func)()`. `execute` may or
+created execution agent calls `std::forward<Function>(func)()`. `possibly_blocking_execute` may or
 may not the caller until execution completes, depending on the value of
 `executor_execute_blocking_guarantee_t<Executor>`. The allocator `alloc` can be
 used to allocate memory for `func`.
 
-`execute` is equivalent to `bulk_execute` except that it creates a group of
+`possibly_blocking_execute` is equivalent to `bulk_possibly_blocking_execute` except that it creates a group of
 execution agents rather than a single execution agent. This means that an
-executor that provides `bulk_execute` could be adapted to make the semantic
-guarantees of `execute` if it were absent, by creating a group with a single
+executor that provides `bulk_possibly_blocking_execute` could be adapted to make the semantic
+guarantees of `possibly_blocking_execute` if it were absent, by creating a group with a single
 execution agent.
 
     // pass func as a shared parameter to account for move-only functions
@@ -1705,35 +1697,35 @@ execution agent.
       result = func();
     };
 
-    exec.bulk_then_execute(g,
+    exec.bulk_twoway_then_possibly_blocking_execute(g,
       executor_shape_t<Executor>{1}, // create a single agent group
       shared_factory
     );
 
-As with the adaptation of `then_execute` described earlier this group has only
+As with the adaptation of `twoway_then_possibly_blocking_execute` described earlier this group has only
 one agent and no sharing actually occurs. The cost of this unnecessary sharing
-may be significant and can be avoided if an executor specializes `then_execute`.
+may be significant and can be avoided if an executor specializes `twoway_then_possibly_blocking_execute`.
 
 # Future Work
 
 We conclude with a survey of future work. Some of this work is in scope for
 P0443 and should be done before the design is considered complete. Other work
 is explicitly out of scope, and should be pursued independently using our
-design as a foundation. 
+design as a foundation.
 
 ## Open Design Issues
 
 Much of our design for executors is well-established. However, some aspects of the
 design remain the subject of ongoing discussion.
 
-### `post` and `defer`
+### `never_blocking_execute` and `never_blocking_continuation_execute`
 
-Execution functions named `post` and `defer` have identical semantics.
+Execution functions named `never_blocking_execute` and `never_blocking_continuation_execute` have identical semantics.
 Specifically this means that, in generic code (i.e. code where the executor
-    type is a template parameter), calls to `post` and `defer` may be interchanged
-without altering program semantics or correctness. Where `post` and `defer` differ
+    type is a template parameter), calls to `never_blocking_execute` and `never_blocking_continuation_execute` may be interchanged
+without altering program semantics or correctness. Where `never_blocking_execute` and `never_blocking_continuation_execute` differ
 is in the information conveyed to the executor about the caller's intent: the
-use of `defer` indicates that the submitted function object represents a
+use of `never_blocking_continuation_execute` indicates that the submitted function object represents a
 continuation of the caller.
 
 Concrete executor implementations can use this information to optimize
@@ -1747,16 +1739,16 @@ throughput and latency.
 // TODO: provide reference to this data
 
 However, all other execution function names represent distinct semantic
-guarantees; `post` and `defer` are the exceptions. To address this
+guarantees; `never_blocking_execute` and `never_blocking_continuation_execute` are the exceptions. To address this
 inconsistency, we may consider providing only one of these functions (i.e.
-`post`) and to introduce a hinting mechanism to convey the additional
+`never_blocking_execute`) and to introduce a hinting mechanism to convey the additional
 information to an executor. Ideally, this mechanism would be extensible to
 allow other hints to be introduced in the future (e.g. a hint to indicate that
 a submitted function object benefits from CPU affinity).
 
 As an example of established practice, the Boost.Asio library uses an ADL
 customization point, named `asio_handler_is_continuation` to provide
-functionality equivalent to `defer`. The library's executors apply this
+functionality equivalent to `never_blocking_continuation_execute`. The library's executors apply this
 function to all submitted function objects to determine when the optimization
 may be applied.
 
@@ -1803,11 +1795,11 @@ The blocking guarantee is not
 There are exceptions to this rule where blocking guarantees are provided at the
 granularity of individual customization points. The two-way `sync_` functions
 are exceptions because it is impossible to return the result of execution in a
-way that does not block the client which created that execution. The `post` and
-`defer` functions are exceptions to the executor's blocking trait because we
+way that does not block the client which created that execution. The `never_blocking_execute` and
+`never_blocking_continuation_execute` functions are exceptions to the executor's blocking trait because we
 desire the ability for a single executor to provide an always-blocking or
-possibly-blocking `execute` as well as the unconditionally never-blocking
-customization points `post` and `defer`. In such a situation, all three of
+possibly-blocking `possibly_blocking_execute` as well as the unconditionally never-blocking
+customization points `never_blocking_execute` and `never_blocking_continuation_execute`. In such a situation, all three of
 these customization points have different semantics.
 
 ## Envisioned Extensions
@@ -1900,8 +1892,9 @@ hierarchy. The interface to such an execution function would look like:
 
     template<class Executor, class Function, class ResultFactory, class... SharedFactories>
     std::invoke_result_t<ResultFactory()>
-    bulk_sync_execute(const Executor& exec, Function f, executor_shape_t<Executor> shape,
-                      ResultFactory result_factory, SharedFactories... shared_factories);
+    bulk_twoway_always_blocking_execute(const Executor& exec, Function f,
+      executor_shape_t<Executor> shape, ResultFactory result_factory,
+      SharedFactories... shared_factories);
 
 In this interface, the `shape` parameter simultaneously describes the hierarchy
 of groups created by this execution function as well as the multidimensional

--- a/wording.md
+++ b/wording.md
@@ -207,7 +207,7 @@ namespace execution {
     constexpr unspecified twoway_never_blocking_execute = unspecified;
     constexpr unspecified twoway_never_blocking_continuation_execute = unspecified;
     constexpr unspecified twoway_always_blocking_execute = unspecified;
-    constexpr unspecified twoway_then_execute = unspecified;
+    constexpr unspecified twoway_then_possibly_blocking_execute = unspecified;
     constexpr unspecified bulk_possibly_blocking_execute = unspecified;
     constexpr unspecified bulk_never_blocking_execute = unspecified;
     constexpr unspecified bulk_never_blocking_continuation_execute = unspecified;
@@ -229,7 +229,7 @@ namespace execution {
   template<class T> struct can_twoway_never_blocking_execute;
   template<class T> struct can_twoway_never_blocking_continuation_execute;
   template<class T> struct can_twoway_always_blocking_execute;
-  template<class T> struct can_twoway_then_execute;
+  template<class T> struct can_twoway_then_possibly_blocking_execute;
   template<class T> struct can_bulk_possibly_blocking_execute;
   template<class T> struct can_bulk_never_blocking_execute;
   template<class T> struct can_bulk_never_blocking_continuation_execute;
@@ -256,8 +256,8 @@ namespace execution {
     can_twoway_never_blocking_continuation_execute<T>::value;
   template<class T> constexpr bool can_twoway_always_blocking_execute_v =
     can_twoway_always_blocking_execute<T>::value;
-  template<class T> constexpr bool can_twoway_then_execute_v =
-    can_twoway_then_execute<T>::value;
+  template<class T> constexpr bool can_twoway_then_possibly_blocking_execute_v =
+    can_twoway_then_possibly_blocking_execute<T>::value;
   template<class T> constexpr bool can_bulk_possibly_blocking_execute_v =
     can_bulk_possibly_blocking_execute<T>::value;
   template<class T> constexpr bool can_bulk_never_blocking_execute_v =
@@ -601,7 +601,7 @@ create groups of execution agents in bulk from a single execution function and r
 a `Future` for awaiting the completion of a submitted function object invoked by
 those execution agents and obtaining its result.
 
-A type `X` satisfies the `BulkTwoWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, `can_bulk_sync_execute_v<X>` is true, `can_bulk_async_execute_v<X>` is true, and `can_bulk_then_execute_v<X>` is true.
+A type `X` satisfies the `BulkTwoWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, `can_bulk_twoway_always_blocking_execute_v<X>` is true, `can_bulk_twoway_possibly_blocking_execute_v<X>` is true, and `can_bulk_twoway_then_possibly_blocking_execute_v<X>` is true.
 
 ### `ExecutorWorkTracker` requirements
 
@@ -720,135 +720,151 @@ When an executor customization point named *NAME* invokes a free execution funct
 
 Whenever `std::experimental::concurrency_v2::execution::`*NAME*`(`*ARGS*`)` is a valid expression, that expression satisfies the syntactic requirements for the free execution function named *NAME* with arity `sizeof...(`*ARGS*`)` with that free execution function's semantics.
 
-### `execute`
+### `possibly_blocking_execute`
 
     namespace {
-      constexpr unspecified execute = unspecified;
+      constexpr unspecified possibly_blocking_execute = unspecified;
     }
 
-The name `execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+The name `possibly_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
 
-* `(E).execute(F, A...)` if `has_execute_member_v<decay_t<decltype(E)>>` is true.
+* `(E).possibly_blocking_execute(F, A...)` if `has_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `execute(E, F, A...)` if `has_execute_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `possibly_blocking_execute(E, F, A...)` if `has_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, F, A...)` is ill-formed.
 
-### `post`
+### `never_blocking_execute`
 
     namespace {
-      constexpr unspecified post = unspecified;
+      constexpr unspecified never_blocking_execute = unspecified;
     }
 
-The name `post` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::post(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+The name `never_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::never_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
 
-* `(E).post(F, A...)` if `has_post_member_v<decay_t<decltype(E)>>` is true.
+* `(E).never_blocking_execute(F, A...)` if `has_never_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `post(E, F, A...)` if `has_post_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `never_blocking_execute(E, F, A...)` if `has_never_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, F, A...)` if `can_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::post(E, F, A...)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::never_blocking_execute(E, F, A...)` is ill-formed.
 
-### `defer`
+### `never_blocking_continuation_execute`
 
     namespace {
-      constexpr unspecified defer = unspecified;
+      constexpr unspecified never_blocking_continuation_execute = unspecified;
     }
 
-The name `defer` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::defer(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+The name `never_blocking_continuation_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::never_blocking_continuation_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
 
-* `(E).defer(F, A...)` if `has_defer_member_v<decay_t<decltype(E)>>` is true.
+* `(E).never_blocking_continuation_execute(F, A...)` if `has_never_blocking_continuation_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `defer(E, F, A...)` if `has_defer_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `never_blocking_continuation_execute(E, F, A...)` if `has_never_blocking_continuation_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::execute(E, F, A...)` if `can_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, F, A...)` if `can_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::defer(E, F, A...)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::never_blocking_continuation_execute(E, F, A...)` is ill-formed.
 
-### `sync_execute`
+### `always_blocking_execute`
 
     namespace {
-      constexpr unspecified sync_execute = unspecified;
+      constexpr unspecified always_blocking_execute = unspecified;
     }
 
-The name `sync_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::sync_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+The name `always_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::always_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
 
-* `(E).sync_execute(F, A...)` if `has_sync_execute_member_v<decay_t<decltype(E)>>` is true.
+* `(E).always_blocking_execute(F, A...)` if `has_always_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `sync_execute(E, F, A...)` if `has_sync_execute_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `always_blocking_execute(E, F, A...)` if `has_always_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, if `can_async_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+* Otherwise, `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, F, A...)` if `can_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, always_blocking_execution>` is true.
 
-        auto __future = std::experimental::concurrency_v2::execution::async_execute(E, F, A...);
+* Otherwise, `std::experimental::concurrency_v2::execution::always_blocking_execute(E, F, A...)` is ill-formed.
+
+### `twoway_possibly_blocking_execute`
+
+    namespace {
+      constexpr unspecified twoway_possibly_blocking_execute = unspecified;
+    }
+
+The name `twoway_possibly_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+
+* `(E).twoway_possibly_blocking_execute(F, A...)` if `has_twoway_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `twoway_possibly_blocking_execute(E, F, A...)` if `has_twoway_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, if `can_possibly_blocking_execute_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `twoway_possibly_blocking_execute`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...)` is ill-formed.
+
+### `twoway_never_blocking_execute`
+
+    namespace {
+      constexpr unspecified twoway_never_blocking_execute = unspecified;
+    }
+
+The name `twoway_never_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::twoway_never_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+
+* `(E).twoway_never_blocking_execute(F, A...)` if `has_twoway_never_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `twoway_never_blocking_execute(E, F, A...)` if `has_twoway_never_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...)` if `can_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+
+* Otherwise, if `can_never_blocking_execute_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `twoway_never_blocking_execute`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::twoway_never_blocking_execute(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_never_blocking_execute(E, F, A...)` is ill-formed.
+
+### `twoway_never_blocking_continuation_execute`
+
+    namespace {
+      constexpr unspecified twoway_never_blocking_continuation_execute = unspecified;
+    }
+
+The name `twoway_never_blocking_continuation_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::twoway_never_blocking_continuation_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+
+* `(E).twoway_never_blocking_continuation_execute(F, A...)` if `has_twoway_never_blocking_continuation_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `twoway_never_blocking_continuation_execute(E, F, A...)` if `has_twoway_never_blocking_continuation_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...)` if `can_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+
+* Otherwise, if `can_never_blocking_continuation_execute_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::possibly_blocking_execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `twoway_never_blocking_continuation_execute`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::twoway_never_blocking_continuation_execute(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_never_blocking_continuation_execute(E, F, A...)` is ill-formed.
+
+### `twoway_always_blocking_execute`
+
+    namespace {
+      constexpr unspecified twoway_always_blocking_execute = unspecified;
+    }
+
+The name `twoway_always_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::twoway_always_blocking_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+
+* `(E).twoway_always_blocking_execute(F, A...)` if `has_twoway_always_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `twoway_always_blocking_execute(E, F, A...)` if `has_twoway_always_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, if `can_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+
+        auto __future = std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, F, A...);
         __future.wait();
         return __future;
 
-* Otherwise, `std::experimental::concurrency_v2::execution::sync_execute(E, F, A...)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_always_blocking_execute(E, F, A...)` is ill-formed.
 
-### `async_execute`
-
-    namespace {
-      constexpr unspecified async_execute = unspecified;
-    }
-
-The name `async_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
-
-* `(E).async_execute(F, A...)` if `has_async_execute_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `async_execute(E, F, A...)` if `has_async_execute_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, if `can_execute_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `async_execute`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` is ill-formed.
-
-### `async_post`
+### `twoway_then_possibly_blocking_execute`
 
     namespace {
-      constexpr unspecified async_post = unspecified;
+      constexpr unspecified twoway_then_possibly_blocking_execute = unspecified;
     }
 
-The name `async_post` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::async_post(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
+The name `twoway_then_possibly_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::twoway_then_possibly_blocking_execute(E, F, P, A...)` for some expressions `E`, `F`, and `P`, and where `A...` represents 0 or 1 expressions, is equivalent to:
 
-* `(E).async_post(F, A...)` if `has_async_post_member_v<decay_t<decltype(E)>>` is true.
+* `(E).twoway_then_possibly_blocking_execute(F, P, A...)` if `has_twoway_then_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `async_post(E, F, A...)` if `has_async_post_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
-
-* Otherwise, if `can_post_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `async_post`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::async_post(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::async_post(E, F, A...)` is ill-formed.
-
-### `async_defer`
-
-    namespace {
-      constexpr unspecified async_defer = unspecified;
-    }
-
-The name `async_defer` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::async_defer(E, F, A...)` for some expressions `E` and `F`, and where `A...` represents 0 or 1 expressions, is equivalent to:
-
-* `(E).async_defer(F, A...)` if `has_async_defer_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `async_defer(E, F, A...)` if `has_async_defer_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::async_execute(E, F, A...)` if `can_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
-
-* Otherwise, if `can_defer_v<decay_t<decltype(E)>>` is true, creates an asynchronous provider with an associated shared state (C++Std [futures.state]). Calls `std::experimental::concurrency_v2::execution::execute(E, g, A...)` where `g` is a function object of unspecified type that performs `DECAY_COPY(F)()`, with the call to `DECAY_COPY` being performed in the thread that called `async_defer`. On successful completion of `DECAY_COPY(F)()`, the return value of `DECAY_COPY(F)()` is atomically stored in the shared state and the shared state is made ready. If `DECAY_COPY(F)()` exits via an exception, the exception is atomically stored in the shared state and the shared state is made ready. The result of the expression `std::experimental::concurrency_v2::execution::async_defer(E, F, A...)` is an object of type `std::experimental::future<result_of_t<decay_t<decltype(F)>>()>` that refers to the shared state.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::async_defer(E, F, A...)` is ill-formed.
-
-### `then_execute`
-
-    namespace {
-      constexpr unspecified then_execute = unspecified;
-    }
-
-The name `then_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::then_execute(E, F, P, A...)` for some expressions `E`, `F`, and `P`, and where `A...` represents 0 or 1 expressions, is equivalent to:
-
-* `(E).then_execute(F, P, A...)` if `has_then_execute_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `then_execute(E, F, P, A...)` if `has_then_execute_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `twoway_then_possibly_blocking_execute(E, F, P, A...)` if `has_twoway_then_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
 * Otherwise, equivalent to
 
@@ -857,7 +873,7 @@ The name `then_execute` denotes a customization point. The effect of the express
           auto __predecessor_result = __predecessor_future.get();
           return __f(__predecessor_result);
         }
-        
+
         return (P).then(E, std::move(__g));
 
     when `P` is a non-`void` future. Otherwise,
@@ -869,148 +885,164 @@ The name `then_execute` denotes a customization point. The effect of the express
 
         return (P).then(E, std::move(__g));
 
-* Otherwise, `std::experimental::concurrency_v2::execution::then_execute(E, F, P, A...)` is ill-formed
+* Otherwise, `std::experimental::concurrency_v2::execution::twoway_then_possibly_blocking_execute(E, F, P, A...)` is ill-formed
 
-### `bulk_execute`
-
-    namespace {
-      constexpr unspecified bulk_execute = unspecified;
-    }
-
-The name `bulk_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
-
-* `(E).bulk_execute(F, S, SF)` if `has_bulk_execute_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `bulk_execute(E, F, S, SF)` if `has_bulk_execute_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` is ill-formed.
-
-### `bulk_post`
+### `bulk_possibly_blocking_execute`
 
     namespace {
-      constexpr unspecified bulk_post = unspecified;
+      constexpr unspecified bulk_possibly_blocking_execute = unspecified;
     }
 
-The name `bulk_post` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_post(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
+The name `bulk_possibly_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
 
-* `(E).bulk_post(F, S, SF)` if `has_bulk_post_member_v<decay_t<decltype(E)>>` is true.
+* `(E).bulk_possibly_blocking_execute(F, S, SF)` if `has_bulk_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `bulk_post(E, F, S, SF)` if `has_bulk_post_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `bulk_possibly_blocking_execute(E, F, S, SF)` if `has_bulk_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(E, F, S, SF)` is ill-formed.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_post(E, F, S, SF)` is ill-formed.
-
-### `bulk_defer`
+### `bulk_never_blocking_execute`
 
     namespace {
-      constexpr unspecified bulk_defer = unspecified;
+      constexpr unspecified bulk_never_blocking_execute = unspecified;
     }
 
-The name `bulk_defer` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_defer(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
+The name `bulk_never_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_never_blocking_execute(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
 
-* `(E).bulk_defer(F, S, SF)` if `has_bulk_defer_member_v<decay_t<decltype(E)>>` is true.
+* `(E).bulk_never_blocking_execute(F, S, SF)` if `has_bulk_never_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `bulk_defer(E, F, S, SF)` if `has_bulk_defer_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `bulk_never_blocking_execute(E, F, S, SF)` if `has_bulk_never_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_execute(E, F, S, SF)` if `can_bulk_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(E, F, S, SF)` if `can_bulk_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_defer(E, F, S, SF)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_never_blocking_execute(E, F, S, SF)` is ill-formed.
 
-### `bulk_sync_execute`
+### `bulk_never_blocking_continuation_execute`
 
     namespace {
-      constexpr unspecified bulk_sync_execute = unspecified;
+      constexpr unspecified bulk_never_blocking_continuation_execute = unspecified;
     }
 
-The name `bulk_sync_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_sync_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+The name `bulk_never_blocking_continuation_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_never_blocking_continuation_execute(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
 
-* `(E).bulk_sync_execute(F, S, RF, SF)` if `has_bulk_sync_execute_member_v<decay_t<decltype(E)>>` is true.
+* `(E).bulk_never_blocking_continuation_execute(F, S, SF)` if `has_bulk_never_blocking_continuation_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `bulk_sync_execute(E, F, S, RF, SF)` if `has_bulk_sync_execute_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `bulk_never_blocking_continuation_execute(E, F, S, SF)` if `has_bulk_never_blocking_continuation_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, if `can_bulk_async_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(E, F, S, SF)` if `can_bulk_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
 
-        auto __future = std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF);
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_never_blocking_continuation_execute(E, F, S, SF)` is ill-formed.
+
+### `bulk_always_blocking_execute`
+
+    namespace {
+      constexpr unspecified bulk_always_blocking_execute = unspecified;
+    }
+
+The name `bulk_always_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_always_blocking_execute(E, F, S, SF)` for some expressions `E`, `F`, `S`, and `SF` is equivalent to:
+
+* `(E).bulk_always_blocking_execute(F, S, SF)` if `has_bulk_always_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `bulk_always_blocking_execute(E, F, S, SF)` if `has_bulk_always_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(E, F, S, SF)` if `can_bulk_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, always_blocking_execution>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_always_blocking_execute(E, F, S, SF)` is ill-formed.
+
+### `bulk_twoway_possibly_blocking_execute`
+
+    namespace {
+      constexpr unspecified bulk_twoway_possibly_blocking_execute = unspecified;
+    }
+
+The name `bulk_twoway_possibly_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+
+* `(E).bulk_twoway_possibly_blocking_execute(F, S, RF, SF)` if `has_bulk_twoway_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF)` if `has_bulk_twoway_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_then_possibly_blocking_execute(E, F, S, std::experimental::make_ready_future(), RF, SF)` if `can_bulk_twoway_then_possibly_blocking_execute_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF)` is ill-formed.
+
+### `bulk_twoway_never_blocking_execute`
+
+    namespace {
+      constexpr unspecified bulk_twoway_never_blocking_execute = unspecified;
+    }
+
+The name `bulk_twoway_never_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+
+* `(E).bulk_twoway_never_blocking_execute(F, S, RF, SF)` if `has_bulk_twoway_never_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `bulk_twoway_never_blocking_execute(E, F, S, RF, SF)` if `has_bulk_twoway_never_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF)` if `can_bulk_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_execute(E, F)` is ill-formed.
+
+### `bulk_twoway_never_blocking_continuation_execute`
+
+    namespace {
+      constexpr unspecified bulk_twoway_never_blocking_continuation_execute = unspecified;
+    }
+
+The name `bulk_twoway_never_blocking_continuation_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_continuation_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+
+* `(E).bulk_twoway_never_blocking_continuation_execute(F, S, RF, SF)` if `has_bulk_twoway_never_blocking_continuation_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `bulk_twoway_never_blocking_continuation_execute(E, F, S, RF, SF)` if `has_bulk_twoway_never_blocking_continuation_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF)` if `can_bulk_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
+
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_continuation_execute(E, F)` is ill-formed.
+
+### `bulk_twoway_always_blocking_execute`
+
+    namespace {
+      constexpr unspecified bulk_twoway_always_blocking_execute = unspecified;
+    }
+
+The name `bulk_twoway_always_blocking_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_twoway_always_blocking_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+
+* `(E).bulk_twoway_always_blocking_execute(F, S, RF, SF)` if `has_bulk_twoway_always_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, `bulk_twoway_always_blocking_execute(E, F, S, RF, SF)` if `has_bulk_twoway_always_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
+
+* Otherwise, if `can_bulk_twoway_possibly_blocking_execute_v<decay_t<decltype(E)>>` is true, equivalent to
+
+        auto __future = std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, RF, SF);
         __future.wait();
         return __future;
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_sync_execute(E, F, S, RF, SF)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_always_blocking_execute(E, F, S, RF, SF)` is ill-formed.
 
-### `bulk_async_execute`
-
-    namespace {
-      constexpr unspecified bulk_async_execute = unspecified;
-    }
-
-The name `bulk_async_execute` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
-
-* `(E).bulk_async_execute(F, S, RF, SF)` if `has_bulk_async_execute_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `bulk_async_execute(E, F, S, RF, SF)` if `has_bulk_async_execute_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_then_execute(E, F, S, std::experimental::make_ready_future(), RF, SF)` if `can_bulk_then_execute_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` is ill-formed.
-
-### `bulk_async_post`
+### `bulk_twoway_then_possibly_blocking_execute`
 
     namespace {
-      constexpr unspecified bulk_async_post = unspecified;
+      constexpr unspecified bulk_twoway_then_possibly_blocking_execute = unspecified;
     }
 
-The name `bulk_async_post` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_async_post(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
+The name `bulk_twoway_then_possibly_blocking_execute` denotes a customization point. The effect of the expression `std::expression::concurrency_v2::execution::bulk_twoway_then_possibly_blocking_execute(E, F, S, P, RF, SF)` for some expressions `E`, `F`, `S`, `P`, `RF`, and `SF` is equivalent to:
 
-* `(E).bulk_async_post(F, S, RF, SF)` if `has_bulk_async_post_member_v<decay_t<decltype(E)>>` is true.
+* `(E).bulk_twoway_then_possibly_blocking_execute(F, S, P, RF, SF)` if `has_bulk_twoway_then_possibly_blocking_execute_member_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `bulk_async_post(E, F, S, RF, SF)` if `has_bulk_async_post_free_function_v<decay_t<decltype(E)>>` is true.
+* Otherwise, `bulk_twoway_then_possibly_blocking_execute(E, F, S, P, RF, SF)` if `has_bulk_twoway_then_possibly_blocking_execute_free_function_v<decay_t<decltype(E)>>` is true.
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_post(E, F)` is ill-formed.
-
-### `bulk_async_defer`
-
-    namespace {
-      constexpr unspecified bulk_async_defer = unspecified;
-    }
-
-The name `bulk_async_defer` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::bulk_async_defer(E, F, S, RF, SF)` for some expressions `E`, `F`, `S`, `RF`, and `SF` is equivalent to:
-
-* `(E).bulk_async_defer(F, S, RF, SF)` if `has_bulk_async_defer_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `bulk_async_defer(E, F, S, RF, SF)` if `has_bulk_async_defer_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_execute(E, F, S, RF, SF)` if `can_bulk_async_execute_v<decay_t<decltype(E)>> && is_same_v<execution_execute_blocking_guarantee_t<decay_t<decltype(E)>>, never_blocking_execution>` is true.
-
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_async_defer(E, F)` is ill-formed.
-
-### `bulk_then_execute`
-
-    namespace {
-      constexpr unspecified bulk_then_execute = unspecified;
-    }
-
-The name `bulk_then_execute` denotes a customization point. The effect of the expression `std::expression::concurrency_v2::execution::bulk_then_execute(E, F, S, P, RF, SF)` for some expressions `E`, `F`, `S`, `P`, `RF`, and `SF` is equivalent to:
-
-* `(E).bulk_then_execute(F, S, P, RF, SF)` if `has_bulk_then_execute_member_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, `bulk_then_execute(E, F, S, P, RF, SF)` if `has_bulk_then_execute_free_function_v<decay_t<decltype(E)>>` is true.
-
-* Otherwise, let `DE` be `decay_t<decltype(E)>`. If `can_then_execute_v<DE> && (has_bulk_sync_execute_member_v<DE> || has_bulk_sync_execute_free_function_v<DE> || has_bulk_async_execute_member_v<DE> || has_bulk_async_execute_free_function_v<DE>)` is true, equivalent to the following:
+* Otherwise, let `DE` be `decay_t<decltype(E)>`. If `can_twoway_possibly_blocking_execute_v<DE> && (has_bulk_twoway_always_blocking_execute_member_v<DE> || has_bulk_twoway_always_blocking_execute_free_function_v<DE> || has_bulk_twoway_possibly_blocking_execute_member_v<DE> || has_bulk_twoway_possibly_blocking_execute_free_function_v<DE>)` is true, equivalent to the following:
 
         auto __f = F;
 
         auto __g = [=](auto& __predecessor)
         {
-          return std::experimental::concurrency_v2::bulk_sync_execute(E, S, RF, SF,
+          return std::experimental::concurrency_v2::bulk_twoway_always_blocking_execute(E, S, RF, SF,
             [=,&__predecessor](auto& __result, auto& __shared)
           {
             __f(__i, __predecessor, __result, __shared);
           });
         };
 
-        return std::experimental::concurrency_v2::execution::then_execute(E, __g, P);
+        return std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, __g, P);
 
     if `P` is a non-`void` future. Otherwise,
 
@@ -1018,37 +1050,39 @@ The name `bulk_then_execute` denotes a customization point. The effect of the ex
 
         auto __g = [=]
         {
-          return std::experimental::concurrency_v2::bulk_sync_execute(E, S, RF, SF,
+          return std::experimental::concurrency_v2::bulk_twoway_always_blocking_execute(E, S, RF, SF,
             [=](auto& __result, auto& __shared)
           {
             __f(__i, __result, __shared);
           });
         };
 
-        return std::experimental::concurrency_v2::execution::then_execute(E, __g, P);
+        return std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(E, __g, P);
 
-    [*Note:* The explicit use of execution function detectors for `bulk_sync_execute` and `bulk_async_execute` above is intentional to avoid cycles in this code. *--end note*]
+    [*Note:* The explicit use of execution function detectors for `bulk_twoway_always_blocking_execute` and `bulk_twoway_possibly_blocking_execute` above is intentional to avoid cycles in this code. *--end note*]
 
-* Otherwise, `std::experimental::concurrency_v2::execution::bulk_then_execute(E, F, S, P, RF, SF)` is ill-formed.
+* Otherwise, `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(E, F, S, P, RF, SF)` is ill-formed.
 
 ### Customization point type traits
 
-    template<class T> struct can_execute;
-    template<class T> struct can_post;
-    template<class T> struct can_defer;
-    template<class T> struct can_sync_execute;
-    template<class T> struct can_async_execute;
-    template<class T> struct can_async_post;
-    template<class T> struct can_async_defer;
-    template<class T> struct can_then_execute;
-    template<class T> struct can_bulk_execute;
-    template<class T> struct can_bulk_post;
-    template<class T> struct can_bulk_defer;
-    template<class T> struct can_bulk_sync_execute;
-    template<class T> struct can_bulk_async_execute;
-    template<class T> struct can_bulk_async_post;
-    template<class T> struct can_bulk_async_defer;
-    template<class T> struct can_bulk_then_execute;
+    template<class T> struct can_possibly_blocking_execute;
+    template<class T> struct can_never_blocking_execute;
+    template<class T> struct can_never_blocking_continuation_execute;
+    template<class T> struct can_always_blocking_execute;
+    template<class T> struct can_twoway_possibly_blocking_execute;
+    template<class T> struct can_twoway_never_blocking_execute;
+    template<class T> struct can_twoway_never_blocking_continuation_execute;
+    template<class T> struct can_twoway_always_blocking_execute;
+    template<class T> struct can_twoway_then_possibly_blocking_execute;
+    template<class T> struct can_bulk_possibly_blocking_execute;
+    template<class T> struct can_bulk_never_blocking_execute;
+    template<class T> struct can_bulk_never_blocking_continuation_execute;
+    template<class T> struct can_bulk_always_blocking_execute;
+    template<class T> struct can_bulk_twoway_possibly_blocking_execute;
+    template<class T> struct can_bulk_twoway_never_blocking_execute;
+    template<class T> struct can_bulk_twoway_never_blocking_continuation_execute;
+    template<class T> struct can_bulk_twoway_always_blocking_execute;
+    template<class T> struct can_bulk_twoway_then_possibly_blocking_execute;
 
 This sub-clause contains templates that may be used to query the properties of a type at compile time. Each of these templates is a UnaryTypeTrait (C++Std [meta.rqmts]) with a BaseCharacteristic of `true_type` if the corresponding condition is true, otherwise `false_type`.
 
@@ -1078,22 +1112,24 @@ In the Table below,
 
 | Template                   | Conditions           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/> `struct can_execute` | The expressions `std::experimental::concurrency_v2::execution::execute(t, f)` and `std::experimental::concurrency_v2::execution::execute(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_post` | The expressions `std::experimental::concurrency_v2::execution::post(t, f)` and `std::experimental::concurrency_v2::execution::post(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_defer` | The expressions `std::experimental::concurrency_v2::execution::defer(t, f)` and `std::experimental::concurrency_v2::execution::defer(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_sync_execute` | The expressions `std::experimental::concurrency_v2::execution::sync_execute(t, f)` and `std::experimental::concurrency_v2::execution::sync_execute(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_async_execute` | The expressions `std::experimental::concurrency_v2::execution::async_execute(t, f)` and `std::experimental::concurrency_v2::execution::async_execute(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_async_post` | The expressions `std::experimental::concurrency_v2::execution::async_post(t, f)` and `std::experimental::concurrency_v2::execution::async_post(t, f, a)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_async_defer` | The expressions `std::experimental::concurrency_v2::execution::async_defer(t, f)` and `std::experimental::concurrency_v2::execution::async_defer(t, f, a)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_then_execute` | The expressions `std::experimental::concurrency_v2::execution::then_execute(t, f, pred)` and `std::experimental::concurrency_v2::execution::then_execute(t, f, pred)` are well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_execute(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_post` | The expression `std::experimental::concurrency_v2::execution::bulk_post(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_defer` | The expression `std::experimental::concurrency_v2::execution::bulk_defer(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_sync_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_sync_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_async_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_async_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_async_post` | The expression `std::experimental::concurrency_v2::execution::bulk_async_post(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_async_defer` | The expression `std::experimental::concurrency_v2::execution::bulk_async_defer(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct can_bulk_then_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_then_execute(t, bcf, s, pred, rf, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/> `struct can_possibly_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::possibly_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::possibly_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_never_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::never_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::never_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_never_blocking_continuation_execute` | The expressions `std::experimental::concurrency_v2::execution::can_never_blocking_continuation_execute(t, f)` and `std::experimental::concurrency_v2::execution::can_never_blocking_continuation_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/> `struct can_always_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::always_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::always_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_twoway_possibly_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::twoway_possibly_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_twoway_never_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::twoway_never_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::twoway_never_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_twoway_never_blocking_continuation_execute` | The expressions `std::experimental::concurrency_v2::execution::twoway_never_blocking_continuation_execute(t, f)` and `std::experimental::concurrency_v2::execution::twoway_never_blocking_continuation_execute(t, f, a)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_twoway_always_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::twoway_always_blocking_execute(t, f)` and `std::experimental::concurrency_v2::execution::twoway_always_blocking_execute(t, f, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_twoway_then_possibly_blocking_execute` | The expressions `std::experimental::concurrency_v2::execution::twoway_then_possibly_blocking_execute(t, f, pred)` and `std::experimental::concurrency_v2::execution::twoway_then_possibly_blocking_execute(t, f, pred, a)` are well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_possibly_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_possibly_blocking_execute(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_never_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_never_blocking_execute(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_never_blocking_continuation_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_never_blocking_continuation_execute(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_always_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_always_blocking_execute(t, bof, s, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_twoway_possibly_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_twoway_possibly_blocking_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_twoway_never_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_twoway_never_blocking_continuation_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_twoway_never_blocking_continuation_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_twoway_always_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_twoway_always_blocking_execute(t, btf, s, rf, sf)` is well-formed. | `T` is a complete type. |
+| `template<class T>` <br/>`struct can_bulk_twoway_then_possibly_blocking_execute` | The expression `std::experimental::concurrency_v2::execution::bulk_twoway_then_possibly_blocking_execute(t, bcf, s, pred, rf, sf)` is well-formed. | `T` is a complete type. |
 
 ## Executor type traits
 
@@ -1101,6 +1137,7 @@ In the Table below,
 
     template<class T> struct is_one_way_executor;
     template<class T> struct is_never_blocking_one_way_executor;
+    template<class T> struct is_always_blocking_one_way_executor;
     template<class T> struct is_two_way_executor;
     template<class T> struct is_bulk_two_way_executor;
 
@@ -1128,16 +1165,16 @@ This sub-clause contains templates that may be used to query the properties of a
     {
       using type = see below;
     };
-    
+
 The type of `executor_future<Executor, T>::type` is determined as follows:
 
-* if `is_two_way_executor<Executor>` is true, `decltype(declval<const Executor&>().async_execute( declval<T(*)()>())`;
+* if `is_two_way_executor<Executor>` is true, `decltype(declval<const Executor&>().twoway_possibly_blocking_execute( declval<T(*)()>())`;
 
 * otherwise, if `is_one_way_executor<Executor>` is true, `std::experimental::future<T>`;
 
 * otherwise, the program is ill formed.
 
-[*Note:* The effect of this specification is that all execute functions of an executor that satisfies the `TwoWayExecutor`, `NeverBlockingTwoWayExecutor`, or `BulkTwoWayExecutor` requirements must utilize the same future type, and that this future type is determined by `async_execute`. Programs may specialize this trait for user-defined `Executor` types. *--end note*]
+[*Note:* The effect of this specification is that all execution functions of an executor that satisfies the `TwoWayExecutor`, `NeverBlockingTwoWayExecutor`, or `BulkTwoWayExecutor` requirements must utilize the same future type, and that this future type is determined by `twoway_possibly_blocking_execute`. Programs may specialize this trait for user-defined `Executor` types. *--end note*]
 
 ### Classifying the mapping of execution agents
 
@@ -1219,7 +1256,7 @@ Programs may use `executor_execute_blocking_guarantee` to query the blocking beh
 executor customization points whose semantics allow the possibility of
 blocking.
 
-[*Note:* These customization points which potentially block are `execute`, `async_execute`, `then_execute`, `bulk_execute`, `bulk_async_execute`, and `bulk_then_execute`. *--end note*]
+[*Note:* These customization points which possibly block are `possibly_blocking_execute`, `twoway_possibly_blocking_execute`, `twoway_then_possibly_blocking_execute`, `bulk_possibly_blocking_execute`, `bulk_twoway_possibly_blocking_execute`, and `bulk_twoway_then_possibly_blocking_execute`. *--end note*]
 
 ## Bulk executor traits
 
@@ -1247,7 +1284,7 @@ Components which create groups of execution agents may use *bulk forward
 progress guarantees* to communicate the forward progress and ordering
 guarantees of these execution agents with respect to other agents within the
 same group.
-  
+
 TODO: *The meanings and relative "strength" of these categores are to be defined.
 Most of the wording for `bulk_sequenced_execution`, `bulk_parallel_execution`,
 and `bulk_unsequenced_execution` can be migrated from S 25.2.3 p2, p3, and
@@ -1262,7 +1299,7 @@ p4, respectively.*
         // exposition only
         template<class T>
         using helper = typename T::shape_type;
-    
+
       public:
         using type = std::experimental::detected_or_t<
           size_t, helper, Executor
@@ -1637,7 +1674,7 @@ class one_way_executor
 public:
   // execution agent creation
   template<class Function, class ProtoAllocator = std::allocator<void>>
-    void execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+    void possibly_blocking_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
 };
 ```
 
@@ -1645,12 +1682,12 @@ Class `one_way_executor` satisfies the `OneWayExecutor` requirements. The target
 
 ```
 template<class Function, class ProtoAllocator>
-  void execute(Function&& f, const ProtoAllocator& a) const;
+  void possibly_blocking_execute(Function&& f, const ProtoAllocator& a) const;
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.possibly_blocking_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
 ### Class `never_blocking_one_way_executor`
 
@@ -1662,11 +1699,11 @@ class never_blocking_one_way_executor
 public:
   // execution agent creation
   template<class Function, class ProtoAllocator = std::allocator<void>>
-    void execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+    void possibly_blocking_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
   template<class Function, class ProtoAllocator = std::allocator<void>>
-    void post(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+    void never_blocking_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
   template<class Function, class ProtoAllocator = std::allocator<void>>
-    void defer(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+    void never_blocking_continuation_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
 };
 ```
 
@@ -1674,30 +1711,30 @@ Class `never_blocking_one_way_executor` satisfies the `NeverBlockingOneWayExecut
 
 ```
 template<class Function, class ProtoAllocator>
-  void execute(Function&& f, const ProtoAllocator& a) const;
+  void possibly_blocking_execute(Function&& f, const ProtoAllocator& a) const;
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.possibly_blocking_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
 ```
 template<class Function, class ProtoAllocator>
-  void post(Function&& f, const ProtoAllocator& a) const;
+  void never_blocking_execute(Function&& f, const ProtoAllocator& a) const;
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.post(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.never_blocking_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
 ```
 template<class Function, class ProtoAllocator>
-  void defer(Function&& f, const ProtoAllocator& a) const;
+  void never_blocking_continuation_execute(Function&& f, const ProtoAllocator& a) const;
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.defer(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.never_blocking_continuation_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
 ### Class `two_way_executor`
 
@@ -1710,10 +1747,10 @@ public:
   // execution agent creation
   template<class Function, class ProtoAllocator = std::allocator<void>>
     result_of_t<decay_t<Function>()>
-      sync_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+      twoway_always_blocking_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
   template<class Function, class ProtoAllocator = std::allocator<void>>
     std::experimental::future<result_of_t<decay_t<Function>()>>
-      async_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
+      twoway_possibly_blocking_execute(Function&& f, const ProtoAllocator& a = ProtoAllocator()) const;
 };
 ```
 
@@ -1722,26 +1759,26 @@ Class `two_way_executor` satisfies the `TwoWayExecutor` requirements. The target
 ```
 template<class Function, class ProtoAllocator>
   result_of_t<decay_t<Function>()>
-    sync_execute(Function&& f, const ProtoAllocator& a);
+    twoway_always_blocking_execute(Function&& f, const ProtoAllocator& a);
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.sync_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.twoway_always_blocking_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
 *Returns:* The return value of `fd()`.
 
 ```
 template<class Function, class ProtoAllocator>
   std::experimental::future<result_of_t<decay_t<Function>()>>
-    async_execute(Function&& f, const ProtoAllocator& a) const;
+    twoway_possibly_blocking_execute(Function&& f, const ProtoAllocator& a) const;
 ```
 
 Let `e` be the target object of `*this`. Let `a1` be the allocator that was specified when the target was set. Let `fd` be the result of `DECAY_COPY(std::forward<Function>(f))`.
 
-*Effects:* Performs `e.async_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
+*Effects:* Performs `e.twoway_possibly_blocking_execute(g, a1)`, where `g` is a function object of unspecified type that, when called as `g()`, performs `fd()`. The allocator `a` is used to allocate any memory required to implement `g`.
 
-*Returns:* A future with an associated shared state that will contain the result of `fd()`. [*Note:* `e.async_execute(g)` may return any future type that satisfies the Future requirements, and not necessarily `std::experimental::future`. One possible implementation approach is for the polymorphic wrapper to attach a continuation to the inner future via that object's `then()` member function. When invoked, this continuation stores the result in the outer future's associated shared and makes that shared state ready. *--end note*]
+*Returns:* A future with an associated shared state that will contain the result of `fd()`. [*Note:* `e.twoway_possibly_blocking_execute(g)` may return any future type that satisfies the Future requirements, and not necessarily `std::experimental::future`. One possible implementation approach is for the polymorphic wrapper to attach a continuation to the inner future via that object's `then()` member function. When invoked, this continuation stores the result in the outer future's associated shared and makes that shared state ready. *--end note*]
 
 ## Thread pools
 
@@ -1769,7 +1806,7 @@ grown via thread attachment. The `static_thread_pool` is expected to be created
 with the use case clearly in mind with the number of threads known by the
 creator. As a result, no default constructor is considered correct for
 arbitrary use cases and `static_thread_pool` does not support any form of
-automatic resizing.   
+automatic resizing.
 
 `static_thread_pool` presents an effectively unbounded input queue and the execution functions of `static_thread_pool`'s associated executors do not block on this input queue.
 
@@ -1782,10 +1819,10 @@ class static_thread_pool
 {
   public:
     class executor_type;
-    
+
     // construction/destruction
     explicit static_thread_pool(std::size_t num_threads);
-    
+
     // nocopy
     static_thread_pool(const static_thread_pool&) = delete;
     static_thread_pool& operator=(const static_thread_pool&) = delete;
@@ -1802,7 +1839,7 @@ class static_thread_pool
     // wait for all threads in the thread pool to complete
     void wait();
 
-    // placeholder for a general approach to getting executors from 
+    // placeholder for a general approach to getting executors from
     // standard contexts.
     executor_type executor() noexcept;
 };
@@ -1949,15 +1986,15 @@ bool operator!=(const static_thread_pool::executor_type& a,
 `ExecutorWorkTracker` requirements. Objects of type
 `static_thread_pool::executor` are associated with a `static_thread_pool`.
 
-The customization points `execute`, `post`, `defer`, `sync_execute`,
-`async_execute`, `async_post`, `async_defer`, `then_execute`, `bulk_execute`,
-`bulk_post`, `bulk_defer`, `bulk_sync_execute`, `bulk_async_execute`,
-`bulk_async_post`, `bulk_async_defer`, and `bulk_then_execute` are well-formed
+The customization points `possibly_blocking_execute`, `never_blocking_execute`, `never_blocking_continuation_execute`, `twoway_always_blocking_execute`,
+`twoway_possibly_blocking_execute`, `twoway_never_blocking_execute`, `twoway_never_blocking_continuation_execute`, `twoway_then_possibly_blocking_execute`, `bulk_possibly_blocking_execute`,
+`bulk_never_blocking_execute`, `bulk_never_blocking_continuation_execute`, `bulk_twoway_always_blocking_execute`, `bulk_twoway_possibly_blocking_execute`,
+`bulk_twoway_never_blocking_execute`, `bulk_twoway_never_blocking_continuation_execute`, and `bulk_twoway_then_possibly_blocking_execute` are well-formed
 for this executor. Function objects submitted using these customization points
 will be executed by the `static_thread_pool`.
 
-For the customization points `execute`, `sync_execute`, `async_execute`,
-`bulk_execute`, `bulk_sync_execute`, and `bulk_async_execute`, if
+For the customization points `possibly_blocking_execute`, `twoway_always_blocking_execute`, `twoway_possibly_blocking_execute`,
+`bulk_possibly_blocking_execute`, `bulk_twoway_always_blocking_execute`, and `bulk_twoway_possibly_execute`, if
 `running_in_this_thread()` is `true`, calls at least one of the submitted
 function objects in the current thread prior to returning from the
 customization point. [*Note:* If this function object exits via an exception,
@@ -2134,7 +2171,7 @@ async(const Executor& exec, Function&& f, Args&&... args);
 *Returns:* Equivalent to:
 
     auto __g = bind(std::forward<Function>(f), std::forward<Args>(args)...);
-    return execution::async_post(exec, [__g = move(__g)]{ return INVOKE(__g); });
+    return execution::twoway_never_blocking_execute(exec, [__g = move(__g)]{ return INVOKE(__g); });
 
 #### `std::experimental::future::then()`
 
@@ -2151,14 +2188,14 @@ future<T>::then(const Executor& exec, Function&& f);
 2. TODO: Concrete specification
 
 The general idea of this overload of `.then()` is that it accepts a
-particular type of `OneWayExecutor` that cannot block in `.execute()`.
+particular type of `OneWayExecutor` that cannot block in `.possibly_blocking_execute()`.
 `.then()` stores `f` as the next continuation in the future state, and when
 the future is ready, creates an execution agent using a copy of `exec`.
 
 One approach is for `.then()` to require a `NeverBlockingOneWayExecutor`, and to
-specify that `.then()` submits the continuation using `exec.post()` if the
+specify that `.then()` submits the continuation using `exec.never_blocking_execute()` if the
 future is already ready at the time when `.then()` is called, and to submit
-using `exec.execute()` otherwise.
+using `exec.possibly_blocking_execute()` otherwise.
 
 #### `std::experimental::shared_future::then()`
 
@@ -2175,15 +2212,15 @@ shared_future<T>::then(const Executor& exec, Function&& f);
 TODO: Concrete specification
 
 The general idea of this overload of `.then()` is that it accepts a
-particular type of `OneWayExecutor` that cannot block in `.execute()`.
+particular type of `OneWayExecutor` that cannot block in `.possibly_blocking_execute()`.
 `.then()` stores `f` as the next continuation in the underlying future
 state, and when the underlying future is ready, creates an execution agent
 using a copy of `exec`.
 
 One approach is for `.then()` to require a `NeverBlockingOneWayExecutor`, and to
-specify that `.then()` submits the continuation using `exec.post()` if the
+specify that `.then()` submits the continuation using `exec.never_blocking_execute()` if the
 future is already ready at the time when `.then()` is called, and to submit
-using `exec.execute()` otherwise.
+using `exec.possibly_blocking_execute()` otherwise.
 
 #### Function template `invoke`
 
@@ -2198,7 +2235,7 @@ invoke(const Executor& exec, Function&& f, Args&&... args);
 
 *Returns:* Equivalent to:
 
-`return execution::sync_execute(exec, [&]{ return INVOKE(f, args...); });`
+`return execution::twoway_always_blocking_execute(exec, [&]{ return INVOKE(f, args...); });`
 
 #### Task block
 

--- a/wording.md
+++ b/wording.md
@@ -431,7 +431,7 @@ The name of an execution function and it's respective customization point is det
 
 The blocking semantics of an execution function may be one of the following:
 
-* *Potentially blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having potentially blocking semantics are named `possibly_blocking_execute`.
+* *Potentially blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having possibly blocking semantics are named `possibly_blocking_execute`.
 * *Never blocking:* The execution function shall not block the caller pending completion of the submitted function objects. Execution functions having never blocking semantics are named `never_blocking_execute` or `never_blocking_continuation_execute`.
 * *Always blocking:* The execution function must block the caller pending completion of the submitted function object. Execution functions having always blocking semantics are named `always_blocking_execute`.
 
@@ -1220,7 +1220,7 @@ agent executes as-if on a `std::thread`. Therefore, the facilities provided by
 particular that thread-local storage will not be shared between execution
 agents. *--end note*]
 
-### Guaranteeing the blocking behavior of potentially blocking operations
+### Guaranteeing the blocking behavior of possibly blocking operations
 
     struct always_blocking_execution {};
     struct possibly_blocking_execution {};
@@ -1240,7 +1240,7 @@ agents. *--end note*]
         >;
     };
 
-Components which create potentially blocking execution may use *blocking guarantees*
+Components which create possibly blocking execution may use *blocking guarantees*
 to communicate the way in which this execution blocks the progress of its caller.
 
 `always_blocking_execution` indicates that a component blocks its caller's

--- a/wording.md
+++ b/wording.md
@@ -85,35 +85,39 @@ namespace execution {
   template<class T> struct has_execute_member;
   template<class T> struct has_post_member;
   template<class T> struct has_defer_member;
-  template<class T> struct has_sync_execute_member;
+  template<class T> struct has_invoke_member;
   template<class T> struct has_async_execute_member;
   template<class T> struct has_async_post_member;
   template<class T> struct has_async_defer_member;
+  template<class T> struct has_async_invoke_member;
   template<class T> struct has_then_execute_member;
   template<class T> struct has_bulk_execute_member;
   template<class T> struct has_bulk_post_member;
   template<class T> struct has_bulk_defer_member;
-  template<class T> struct has_bulk_sync_execute_member;
+  template<class T> struct has_bulk_invoke_member;
   template<class T> struct has_bulk_async_execute_member;
   template<class T> struct has_bulk_async_post_member;
   template<class T> struct has_bulk_async_defer_member;
+  template<class T> struct has_bulk_async_invoke_member;
   template<class T> struct has_bulk_then_execute_member;
 
   template<class T> constexpr bool has_execute_member_v = has_execute_member<T>::value;
   template<class T> constexpr bool has_post_member_v = has_post_member<T>::value;
   template<class T> constexpr bool has_defer_member_v = has_defer_member<T>::value;
-  template<class T> constexpr bool has_sync_execute_member_v = has_sync_execute_member<T>::value;
+  template<class T> constexpr bool has_invoke_member_v = has_invoke_member<T>::value;
   template<class T> constexpr bool has_async_execute_member_v = has_async_execute_member<T>::value;
   template<class T> constexpr bool has_async_post_member_v = has_async_post_member<T>::value;
   template<class T> constexpr bool has_async_defer_member_v = has_async_defer_member<T>::value;
+  template<class T> constexpr bool has_async_invoke_member_v = has_async_invoke_member<T>::value;
   template<class T> constexpr bool has_then_execute_member_v = has_then_execute_member<T>::value;
   template<class T> constexpr bool has_bulk_execute_member_v = has_bulk_execute_member<T>::value;
   template<class T> constexpr bool has_bulk_post_member_v = has_bulk_post_member<T>::value;
   template<class T> constexpr bool has_bulk_defer_member_v = has_bulk_defer_member<T>::value;
-  template<class T> constexpr bool has_bulk_sync_execute_member_v = has_bulk_sync_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_invoke_member_v = has_bulk_invoke_member<T>::value;
   template<class T> constexpr bool has_bulk_async_execute_member_v = has_bulk_async_execute_member<T>::value;
   template<class T> constexpr bool has_bulk_async_post_member_v = has_bulk_async_post_member<T>::value;
   template<class T> constexpr bool has_bulk_async_defer_member_v = has_bulk_async_defer_member<T>::value;
+  template<class T> constexpr bool has_bulk_async_invoke_member_v = has_bulk_async_invoke_member<T>::value;
   template<class T> constexpr bool has_bulk_then_execute_member_v = has_bulk_then_execute_member<T>::value;
 
   // Free function detection type traits:
@@ -121,35 +125,39 @@ namespace execution {
   template<class T> struct has_execute_free_function;
   template<class T> struct has_post_free_function;
   template<class T> struct has_defer_free_function;
-  template<class T> struct has_sync_execute_free_function;
+  template<class T> struct has_invoke_free_function;
   template<class T> struct has_async_execute_free_function;
   template<class T> struct has_async_post_free_function;
   template<class T> struct has_async_defer_free_function;
+  template<class T> struct has_async_invoke_free_function;
   template<class T> struct has_then_execute_free_function;
   template<class T> struct has_bulk_execute_free_function;
   template<class T> struct has_bulk_post_free_function;
   template<class T> struct has_bulk_defer_free_function;
-  template<class T> struct has_bulk_sync_execute_free_function;
+  template<class T> struct has_bulk_invoke_free_function;
   template<class T> struct has_bulk_async_execute_free_function;
   template<class T> struct has_bulk_async_post_free_function;
   template<class T> struct has_bulk_async_defer_free_function;
+  template<class T> struct has_bulk_async_invoke_free_function;
   template<class T> struct has_bulk_then_execute_free_function;
 
   template<class T> constexpr bool has_execute_free_function_v = has_execute_free_function<T>::value;
   template<class T> constexpr bool has_post_free_function_v = has_post_free_function<T>::value;
   template<class T> constexpr bool has_defer_free_function_v = has_defer_free_function<T>::value;
-  template<class T> constexpr bool has_sync_execute_free_function_v = has_sync_execute_free_function<T>::value;
+  template<class T> constexpr bool has_invoke_free_function_v = has_invoke_free_function<T>::value;
   template<class T> constexpr bool has_async_execute_free_function_v = has_async_execute_free_function<T>::value;
   template<class T> constexpr bool has_async_post_free_function_v = has_async_post_free_function<T>::value;
   template<class T> constexpr bool has_async_defer_free_function_v = has_async_defer_free_function<T>::value;
+  template<class T> constexpr bool has_async_invoke_free_function_v = has_async_invoke_free_function<T>::value;
   template<class T> constexpr bool has_then_execute_free_function_v = has_then_execute_free_function<T>::value;
   template<class T> constexpr bool has_bulk_execute_free_function_v = has_bulk_execute_free_function<T>::value;
   template<class T> constexpr bool has_bulk_post_free_function_v = has_bulk_post_free_function<T>::value;
   template<class T> constexpr bool has_bulk_defer_free_function_v = has_bulk_defer_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_sync_execute_free_function_v = has_bulk_sync_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_invoke_free_function_v = has_bulk_invoke_free_function<T>::value;
   template<class T> constexpr bool has_bulk_async_execute_free_function_v = has_bulk_async_execute_free_function<T>::value;
   template<class T> constexpr bool has_bulk_async_post_free_function_v = has_bulk_async_post_free_function<T>::value;
   template<class T> constexpr bool has_bulk_async_defer_free_function_v = has_bulk_async_defer_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_async_invoke_free_function_v = has_bulk_async_invoke_free_function<T>::value;
   template<class T> constexpr bool has_bulk_then_execute_free_function_v = has_bulk_then_execute_free_function<T>::value;
 
   // Customization points:
@@ -158,18 +166,20 @@ namespace execution {
     constexpr unspecified execute = unspecified;
     constexpr unspecified post = unspecified;
     constexpr unspecified defer = unspecified;
-    constexpr unspecified sync_execute = unspecified;
+    constexpr unspecified invoke = unspecified;
     constexpr unspecified async_execute = unspecified;
     constexpr unspecified async_post = unspecified;
     constexpr unspecified async_defer = unspecified;
+    constexpr unspecified async_invoke = unspecified;
     constexpr unspecified then_execute = unspecified;
     constexpr unspecified bulk_execute = unspecified;
     constexpr unspecified bulk_post = unspecified;
     constexpr unspecified bulk_defer = unspecified;
-    constexpr unspecified bulk_sync_execute = unspecified;
+    constexpr unspecified bulk_invoke = unspecified;
     constexpr unspecified bulk_async_execute = unspecified;
     constexpr unspecified bulk_async_post = unspecified;
     constexpr unspecified bulk_async_defer = unspecified;
+    constexpr unspecified bulk_async_invoke = unspecified;
     constexpr unspecified bulk_then_execute = unspecified;
   }
 
@@ -178,46 +188,52 @@ namespace execution {
   template<class T> struct can_execute;
   template<class T> struct can_post;
   template<class T> struct can_defer;
-  template<class T> struct can_sync_execute;
+  template<class T> struct can_invoke;
   template<class T> struct can_async_execute;
   template<class T> struct can_async_post;
   template<class T> struct can_async_defer;
+  template<class T> struct can_async_invoke;
   template<class T> struct can_then_execute;
   template<class T> struct can_bulk_execute;
-  template<class T> struct can_post_execute;
-  template<class T> struct can_defer_execute;
-  template<class T> struct can_bulk_sync_execute;
+  template<class T> struct can_bulk_post;
+  template<class T> struct can_bulk_defer;
+  template<class T> struct can_bulk_invoke;
   template<class T> struct can_bulk_async_execute;
   template<class T> struct can_bulk_async_post;
   template<class T> struct can_bulk_async_defer;
+  template<class T> struct can_bulk_async_invoke;
   template<class T> struct can_bulk_then_execute;
 
   template<class T> constexpr bool can_execute_v = can_execute<T>::value;
   template<class T> constexpr bool can_post_v = can_post<T>::value;
   template<class T> constexpr bool can_defer_v = can_defer<T>::value;
-  template<class T> constexpr bool can_sync_execute_v = can_sync_execute<T>::value;
+  template<class T> constexpr bool can_invoke_v = can_invoke<T>::value;
   template<class T> constexpr bool can_async_execute_v = can_async_execute<T>::value;
   template<class T> constexpr bool can_async_post_v = can_async_post<T>::value;
   template<class T> constexpr bool can_async_defer_v = can_async_defer<T>::value;
+  template<class T> constexpr bool can_async_invoke_v = can_async_invoke<T>::value;
   template<class T> constexpr bool can_then_execute_v = can_then_execute<T>::value;
   template<class T> constexpr bool can_bulk_execute_v = can_bulk_execute<T>::value;
   template<class T> constexpr bool can_bulk_post_v = can_bulk_post<T>::value;
   template<class T> constexpr bool can_bulk_defer_v = can_bulk_defer<T>::value;
-  template<class T> constexpr bool can_bulk_sync_execute_v = can_bulk_sync_execute<T>::value;
+  template<class T> constexpr bool can_bulk_invoke_v = can_bulk_invoke<T>::value;
   template<class T> constexpr bool can_bulk_async_execute_v = can_bulk_async_execute<T>::value;
   template<class T> constexpr bool can_bulk_async_post_v = can_bulk_async_post<T>::value;
   template<class T> constexpr bool can_bulk_async_defer_v = can_bulk_async_defer<T>::value;
+  template<class T> constexpr bool can_bulk_async_invoke_v = can_bulk_async_invoke<T>::value;
   template<class T> constexpr bool can_bulk_then_execute_v = can_bulk_then_execute<T>::value;
 
   // Executor type traits:
 
   template<class T> struct is_one_way_executor;
   template<class T> struct is_non_blocking_one_way_executor;
+  template<class T> struct is_always_blocking_one_way_executor;
   template<class T> struct is_two_way_executor;
   template<class T> struct is_bulk_two_way_executor;
 
   template<class T> constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
   template<class T> constexpr bool is_non_blocking_one_way_executor_v = is_non_blocking_one_way_executor<T>::value;
+  template<class T> constexpr bool is_always_blocking_one_way_executor_v = is_always_blocking_one_way_executor<T>::value;
   template<class T> constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
   template<class T> constexpr bool is_bulk_two_way_executor_v = is_bulk_two_way_executor<T>::value;
 

--- a/wording.md
+++ b/wording.md
@@ -82,157 +82,211 @@ namespace execution {
 
   // Member detection type traits:
 
-  template<class T> struct has_execute_member;
-  template<class T> struct has_post_member;
-  template<class T> struct has_defer_member;
-  template<class T> struct has_invoke_member;
-  template<class T> struct has_async_execute_member;
-  template<class T> struct has_async_post_member;
-  template<class T> struct has_async_defer_member;
-  template<class T> struct has_async_invoke_member;
-  template<class T> struct has_then_execute_member;
-  template<class T> struct has_bulk_execute_member;
-  template<class T> struct has_bulk_post_member;
-  template<class T> struct has_bulk_defer_member;
-  template<class T> struct has_bulk_invoke_member;
-  template<class T> struct has_bulk_async_execute_member;
-  template<class T> struct has_bulk_async_post_member;
-  template<class T> struct has_bulk_async_defer_member;
-  template<class T> struct has_bulk_async_invoke_member;
-  template<class T> struct has_bulk_then_execute_member;
+  template<class T> struct has_possibly_blocking_execute_member;
+  template<class T> struct has_never_blocking_execute_member;
+  template<class T> struct has_never_blocking_continuation_execute_member;
+  template<class T> struct has_always_blocking_execute_member;
+  template<class T> struct has_twoway_possibly_blocking_execute_member;
+  template<class T> struct has_twoway_never_blocking_execute_member;
+  template<class T> struct has_twoway_never_blocking_continuation_execute_member;
+  template<class T> struct has_twoway_always_blocking_execute_member;
+  template<class T> struct has_twoway_then_possibly_blocking_execute_member;
+  template<class T> struct has_bulk_possibly_blocking_execute_member;
+  template<class T> struct has_bulk_never_blocking_execute_member;
+  template<class T> struct has_bulk_never_blocking_continuation_execute_member;
+  template<class T> struct has_bulk_always_blocking_execute_member;
+  template<class T> struct has_bulk_twoway_possibly_blocking_execute_member;
+  template<class T> struct has_bulk_twoway_never_blocking_execute_member;
+  template<class T> struct has_bulk_twoway_never_blocking_continuation_execute_member;
+  template<class T> struct has_bulk_twoway_always_blocking_execute_member;
+  template<class T> struct has_bulk_twoway_then_possibly_blocking_execute_member;
 
-  template<class T> constexpr bool has_execute_member_v = has_execute_member<T>::value;
-  template<class T> constexpr bool has_post_member_v = has_post_member<T>::value;
-  template<class T> constexpr bool has_defer_member_v = has_defer_member<T>::value;
-  template<class T> constexpr bool has_invoke_member_v = has_invoke_member<T>::value;
-  template<class T> constexpr bool has_async_execute_member_v = has_async_execute_member<T>::value;
-  template<class T> constexpr bool has_async_post_member_v = has_async_post_member<T>::value;
-  template<class T> constexpr bool has_async_defer_member_v = has_async_defer_member<T>::value;
-  template<class T> constexpr bool has_async_invoke_member_v = has_async_invoke_member<T>::value;
-  template<class T> constexpr bool has_then_execute_member_v = has_then_execute_member<T>::value;
-  template<class T> constexpr bool has_bulk_execute_member_v = has_bulk_execute_member<T>::value;
-  template<class T> constexpr bool has_bulk_post_member_v = has_bulk_post_member<T>::value;
-  template<class T> constexpr bool has_bulk_defer_member_v = has_bulk_defer_member<T>::value;
-  template<class T> constexpr bool has_bulk_invoke_member_v = has_bulk_invoke_member<T>::value;
-  template<class T> constexpr bool has_bulk_async_execute_member_v = has_bulk_async_execute_member<T>::value;
-  template<class T> constexpr bool has_bulk_async_post_member_v = has_bulk_async_post_member<T>::value;
-  template<class T> constexpr bool has_bulk_async_defer_member_v = has_bulk_async_defer_member<T>::value;
-  template<class T> constexpr bool has_bulk_async_invoke_member_v = has_bulk_async_invoke_member<T>::value;
-  template<class T> constexpr bool has_bulk_then_execute_member_v = has_bulk_then_execute_member<T>::value;
+  template<class T> constexpr bool has_possibly_blocking_execute_member_v =
+    has_possibly_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_never_blocking_execute_member_v =
+    has_never_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_never_blocking_continuation_execute_member_v =
+    has_never_blocking_continuation_execute_member<T>::value;
+  template<class T> constexpr bool has_always_blocking_execute_member_v =
+    has_always_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_twoway_possibly_blocking_execute_member_v =
+    has_twoway_possibly_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_twoway_never_blocking_execute_member_v =
+    has_twoway_never_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_twoway_never_blocking_continuation_execute_member_v =
+    has_twoway_never_blocking_continuation_execute_member<T>::value;
+  template<class T> constexpr bool has_twoway_always_blocking_execute_member_v =
+    has_twoway_always_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_twoway_then_possibly_blocking_execute_member_v =
+    has_twoway_then_possibly_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_possibly_blocking_execute_member_v =
+    has_bulk_possibly_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_never_blocking_execute_member_v =
+    has_bulk_never_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_never_blocking_continuation_execute_member_v =
+    has_bulk_never_blocking_continuation_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_always_blocking_execute_member_v =
+    has_bulk_always_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_possibly_blocking_execute_member_v =
+    has_bulk_twoway_possibly_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_never_blocking_execute_member_v =
+    has_bulk_twoway_never_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_never_blocking_continuation_execute_member_v =
+    has_bulk_twoway_never_blocking_continuation_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_always_blocking_execute_member_v =
+    has_bulk_twoway_always_blocking_execute_member<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_then_possibly_blocking_execute_member_v =
+    has_bulk_twoway_then_possibly_blocking_execute_member<T>::value;
 
   // Free function detection type traits:
 
-  template<class T> struct has_execute_free_function;
-  template<class T> struct has_post_free_function;
-  template<class T> struct has_defer_free_function;
-  template<class T> struct has_invoke_free_function;
-  template<class T> struct has_async_execute_free_function;
-  template<class T> struct has_async_post_free_function;
-  template<class T> struct has_async_defer_free_function;
-  template<class T> struct has_async_invoke_free_function;
-  template<class T> struct has_then_execute_free_function;
-  template<class T> struct has_bulk_execute_free_function;
-  template<class T> struct has_bulk_post_free_function;
-  template<class T> struct has_bulk_defer_free_function;
-  template<class T> struct has_bulk_invoke_free_function;
-  template<class T> struct has_bulk_async_execute_free_function;
-  template<class T> struct has_bulk_async_post_free_function;
-  template<class T> struct has_bulk_async_defer_free_function;
-  template<class T> struct has_bulk_async_invoke_free_function;
-  template<class T> struct has_bulk_then_execute_free_function;
+  template<class T> struct has_possibly_blocking_execute_free_function;
+  template<class T> struct has_never_blocking_execute_free_function;
+  template<class T> struct has_never_blocking_continuation_execute_free_function;
+  template<class T> struct has_always_blocking_execute_free_function;
+  template<class T> struct has_twoway_possibly_blocking_execute_free_function;
+  template<class T> struct has_twoway_never_blocking_execute_free_function;
+  template<class T> struct has_twoway_never_blocking_continuation_execute_free_function;
+  template<class T> struct has_twoway_always_blocking_execute_free_function;
+  template<class T> struct has_twoway_then_possibly_blocking_execute_free_function;
+  template<class T> struct has_bulk_possibly_blocking_execute_free_function;
+  template<class T> struct has_bulk_never_blocking_execute_free_function;
+  template<class T> struct has_bulk_never_blocking_continuation_execute_free_function;
+  template<class T> struct has_bulk_always_blocking_execute_free_function;
+  template<class T> struct has_bulk_twoway_possibly_blocking_execute_free_function;
+  template<class T> struct has_bulk_twoway_never_blocking_execute_free_function;
+  template<class T> struct has_bulk_twoway_never_blocking_continuation_execute_free_function;
+  template<class T> struct has_bulk_twoway_always_blocking_execute_free_function;
+  template<class T> struct has_bulk_twoway_then_possibly_blocking_execute_free_function;
 
-  template<class T> constexpr bool has_execute_free_function_v = has_execute_free_function<T>::value;
-  template<class T> constexpr bool has_post_free_function_v = has_post_free_function<T>::value;
-  template<class T> constexpr bool has_defer_free_function_v = has_defer_free_function<T>::value;
-  template<class T> constexpr bool has_invoke_free_function_v = has_invoke_free_function<T>::value;
-  template<class T> constexpr bool has_async_execute_free_function_v = has_async_execute_free_function<T>::value;
-  template<class T> constexpr bool has_async_post_free_function_v = has_async_post_free_function<T>::value;
-  template<class T> constexpr bool has_async_defer_free_function_v = has_async_defer_free_function<T>::value;
-  template<class T> constexpr bool has_async_invoke_free_function_v = has_async_invoke_free_function<T>::value;
-  template<class T> constexpr bool has_then_execute_free_function_v = has_then_execute_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_execute_free_function_v = has_bulk_execute_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_post_free_function_v = has_bulk_post_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_defer_free_function_v = has_bulk_defer_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_invoke_free_function_v = has_bulk_invoke_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_async_execute_free_function_v = has_bulk_async_execute_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_async_post_free_function_v = has_bulk_async_post_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_async_defer_free_function_v = has_bulk_async_defer_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_async_invoke_free_function_v = has_bulk_async_invoke_free_function<T>::value;
-  template<class T> constexpr bool has_bulk_then_execute_free_function_v = has_bulk_then_execute_free_function<T>::value;
+  template<class T> constexpr bool has_possibly_blocking_execute_free_function_v =
+    has_possibly_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_never_blocking_execute_free_function_v =
+    has_never_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_never_blocking_continuation_execute_free_function_v =
+    has_never_blocking_continuation_execute_free_function<T>::value;
+  template<class T> constexpr bool has_always_blocking_execute_free_function_v =
+    has_always_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_twoway_possibly_blocking_execute_free_function_v =
+    has_twoway_possibly_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_twoway_never_blocking_execute_free_function_v =
+    has_twoway_never_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_twoway_never_blocking_continuation_execute_free_function_v =
+    has_twoway_never_blocking_continuation_execute_free_function<T>::value;
+  template<class T> constexpr bool has_twoway_always_blocking_execute_free_function_v =
+    has_twoway_always_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_twoway_then_possibly_blocking_execute_free_function_v =
+    has_twoway_then_possibly_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_possibly_blocking_execute_free_function_v =
+    has_bulk_possibly_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_never_blocking_execute_free_function_v =
+    has_bulk_never_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_never_blocking_continuation_execute_free_function_v =
+    has_bulk_never_blocking_continuation_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_always_blocking_execute_free_function_v =
+    has_bulk_always_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_possibly_blocking_execute_free_function_v =
+    has_bulk_twoway_possibly_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_never_blocking_execute_free_function_v =
+    has_bulk_twoway_never_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_never_blocking_continuation_execute_free_function_v =
+    has_bulk_twoway_never_blocking_continuation_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_always_blocking_execute_free_function_v =
+    has_bulk_twoway_always_blocking_execute_free_function<T>::value;
+  template<class T> constexpr bool has_bulk_twoway_then_possibly_blocking_execute_free_function_v =
+    has_bulk_twoway_then_possibly_blocking_execute_free_function<T>::value;
 
   // Customization points:
 
   namespace {
-    constexpr unspecified execute = unspecified;
-    constexpr unspecified post = unspecified;
-    constexpr unspecified defer = unspecified;
-    constexpr unspecified invoke = unspecified;
-    constexpr unspecified async_execute = unspecified;
-    constexpr unspecified async_post = unspecified;
-    constexpr unspecified async_defer = unspecified;
-    constexpr unspecified async_invoke = unspecified;
-    constexpr unspecified then_execute = unspecified;
-    constexpr unspecified bulk_execute = unspecified;
-    constexpr unspecified bulk_post = unspecified;
-    constexpr unspecified bulk_defer = unspecified;
-    constexpr unspecified bulk_invoke = unspecified;
-    constexpr unspecified bulk_async_execute = unspecified;
-    constexpr unspecified bulk_async_post = unspecified;
-    constexpr unspecified bulk_async_defer = unspecified;
-    constexpr unspecified bulk_async_invoke = unspecified;
-    constexpr unspecified bulk_then_execute = unspecified;
+    constexpr unspecified possibly_blocking_execute = unspecified;
+    constexpr unspecified never_blocking_execute = unspecified;
+    constexpr unspecified never_blocking_continuation_execute = unspecified;
+    constexpr unspecified always_blocking_execute = unspecified;
+    constexpr unspecified twoway_possibly_blocking_execute = unspecified;
+    constexpr unspecified twoway_never_blocking_execute = unspecified;
+    constexpr unspecified twoway_never_blocking_continuation_execute = unspecified;
+    constexpr unspecified twoway_always_blocking_execute = unspecified;
+    constexpr unspecified twoway_then_execute = unspecified;
+    constexpr unspecified bulk_possibly_blocking_execute = unspecified;
+    constexpr unspecified bulk_never_blocking_execute = unspecified;
+    constexpr unspecified bulk_never_blocking_continuation_execute = unspecified;
+    constexpr unspecified bulk_always_blocking_execute = unspecified;
+    constexpr unspecified bulk_twoway_possibly_blocking_execute = unspecified;
+    constexpr unspecified bulk_twoway_never_blocking_execute = unspecified;
+    constexpr unspecified bulk_twoway_never_blocking_continuation_execute = unspecified;
+    constexpr unspecified bulk_twoway_always_blocking_execute = unspecified;
+    constexpr unspecified bulk_twoway_then_possibly_blocking_execute = unspecified;
   }
 
   // Customization point type traits:
 
-  template<class T> struct can_execute;
-  template<class T> struct can_post;
-  template<class T> struct can_defer;
-  template<class T> struct can_invoke;
-  template<class T> struct can_async_execute;
-  template<class T> struct can_async_post;
-  template<class T> struct can_async_defer;
-  template<class T> struct can_async_invoke;
-  template<class T> struct can_then_execute;
-  template<class T> struct can_bulk_execute;
-  template<class T> struct can_bulk_post;
-  template<class T> struct can_bulk_defer;
-  template<class T> struct can_bulk_invoke;
-  template<class T> struct can_bulk_async_execute;
-  template<class T> struct can_bulk_async_post;
-  template<class T> struct can_bulk_async_defer;
-  template<class T> struct can_bulk_async_invoke;
-  template<class T> struct can_bulk_then_execute;
+  template<class T> struct can_possibly_blocking_execute;
+  template<class T> struct can_never_blocking_execute;
+  template<class T> struct can_never_blocking_continuation_execute;
+  template<class T> struct can_always_blocking_execute;
+  template<class T> struct can_twoway_possibly_blocking_execute;
+  template<class T> struct can_twoway_never_blocking_execute;
+  template<class T> struct can_twoway_never_blocking_continuation_execute;
+  template<class T> struct can_twoway_always_blocking_execute;
+  template<class T> struct can_twoway_then_execute;
+  template<class T> struct can_bulk_possibly_blocking_execute;
+  template<class T> struct can_bulk_never_blocking_execute;
+  template<class T> struct can_bulk_never_blocking_continuation_execute;
+  template<class T> struct can_bulk_always_blocking_execute;
+  template<class T> struct can_bulk_twoway_possibly_blocking_execute;
+  template<class T> struct can_bulk_twoway_never_blocking_execute;
+  template<class T> struct can_bulk_twoway_never_blocking_continuation_execute;
+  template<class T> struct can_bulk_twoway_always_blocking_execute;
+  template<class T> struct can_bulk_twoway_then_possibly_blocking_execute;
 
-  template<class T> constexpr bool can_execute_v = can_execute<T>::value;
-  template<class T> constexpr bool can_post_v = can_post<T>::value;
-  template<class T> constexpr bool can_defer_v = can_defer<T>::value;
-  template<class T> constexpr bool can_invoke_v = can_invoke<T>::value;
-  template<class T> constexpr bool can_async_execute_v = can_async_execute<T>::value;
-  template<class T> constexpr bool can_async_post_v = can_async_post<T>::value;
-  template<class T> constexpr bool can_async_defer_v = can_async_defer<T>::value;
-  template<class T> constexpr bool can_async_invoke_v = can_async_invoke<T>::value;
-  template<class T> constexpr bool can_then_execute_v = can_then_execute<T>::value;
-  template<class T> constexpr bool can_bulk_execute_v = can_bulk_execute<T>::value;
-  template<class T> constexpr bool can_bulk_post_v = can_bulk_post<T>::value;
-  template<class T> constexpr bool can_bulk_defer_v = can_bulk_defer<T>::value;
-  template<class T> constexpr bool can_bulk_invoke_v = can_bulk_invoke<T>::value;
-  template<class T> constexpr bool can_bulk_async_execute_v = can_bulk_async_execute<T>::value;
-  template<class T> constexpr bool can_bulk_async_post_v = can_bulk_async_post<T>::value;
-  template<class T> constexpr bool can_bulk_async_defer_v = can_bulk_async_defer<T>::value;
-  template<class T> constexpr bool can_bulk_async_invoke_v = can_bulk_async_invoke<T>::value;
-  template<class T> constexpr bool can_bulk_then_execute_v = can_bulk_then_execute<T>::value;
+  template<class T> constexpr bool can_possibly_blocking_execute_v =
+    can_possibly_blocking_execute<T>::value;
+  template<class T> constexpr bool can_never_blocking_execute_v =
+    can_never_blocking_execute<T>::value;
+  template<class T> constexpr bool can_never_blocking_continuation_execute_v =
+    can_never_blocking_continuation_execute<T>::value;
+  template<class T> constexpr bool can_always_blocking_execute_v =
+    can_always_blocking_execute<T>::value;
+  template<class T> constexpr bool can_twoway_possibly_blocking_execute_v =
+    can_twoway_possibly_blocking_execute<T>::value;
+  template<class T> constexpr bool can_twoway_never_blocking_execute_v =
+    can_twoway_never_blocking_execute<T>::value;
+  template<class T> constexpr bool can_twoway_never_blocking_continuation_execute_v =
+    can_twoway_never_blocking_continuation_execute<T>::value;
+  template<class T> constexpr bool can_twoway_always_blocking_execute_v =
+    can_twoway_always_blocking_execute<T>::value;
+  template<class T> constexpr bool can_twoway_then_execute_v =
+    can_twoway_then_execute<T>::value;
+  template<class T> constexpr bool can_bulk_possibly_blocking_execute_v =
+    can_bulk_possibly_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_never_blocking_execute_v =
+    can_bulk_never_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_never_blocking_continuation_execute_v =
+    can_bulk_never_blocking_continuation_execute<T>::value;
+  template<class T> constexpr bool can_bulk_always_blocking_execute_v =
+    can_bulk_always_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_twoway_possibly_blocking_execute_v =
+    can_bulk_twoway_possibly_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_twoway_never_blocking_execute_v =
+    can_bulk_twoway_never_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_twoway_never_blocking_continuation_execute_v =
+    can_bulk_twoway_never_blocking_continuation_execute<T>::value;
+  template<class T> constexpr bool can_bulk_twoway_always_blocking_execute_v =
+    can_bulk_twoway_always_blocking_execute<T>::value;
+  template<class T> constexpr bool can_bulk_twoway_then_possibly_blocking_execute_v =
+    can_bulk_twoway_then_possibly_blocking_execute<T>::value;
 
   // Executor type traits:
 
   template<class T> struct is_one_way_executor;
-  template<class T> struct is_non_blocking_one_way_executor;
+  template<class T> struct is_never_blocking_one_way_executor;
   template<class T> struct is_always_blocking_one_way_executor;
   template<class T> struct is_two_way_executor;
   template<class T> struct is_bulk_two_way_executor;
 
   template<class T> constexpr bool is_one_way_executor_v = is_one_way_executor<T>::value;
-  template<class T> constexpr bool is_non_blocking_one_way_executor_v = is_non_blocking_one_way_executor<T>::value;
+  template<class T> constexpr bool is_never_blocking_one_way_executor_v = is_never_blocking_one_way_executor<T>::value;
   template<class T> constexpr bool is_always_blocking_one_way_executor_v = is_always_blocking_one_way_executor<T>::value;
   template<class T> constexpr bool is_two_way_executor_v = is_two_way_executor<T>::value;
   template<class T> constexpr bool is_bulk_two_way_executor_v = is_bulk_two_way_executor<T>::value;
@@ -258,7 +312,7 @@ namespace execution {
 
   struct blocking_execution_tag {};
   struct possibly_blocking_execution_tag {};
-  struct non_blocking_execution_tag {};
+  struct never_blocking_execution_tag {};
 
   template<class Executor> struct executor_execute_blocking_category;
 
@@ -355,7 +409,7 @@ The name of an execution function is determined by the combination of its proper
 
 | Cardinality | Directionality | Blocking semantics |
 |-------------|----------------|--------------------|
-| `""` or `"bulk_"` | `""` or `"sync_"` or `"async_"` or `"then_"` | `"execute"` or `"post"` or `"defer"` |
+| `""` or `"bulk_"` | `""` or `"twoway_"` or `"twoway_then_"` | `"possibly_blocking_execute"` or `"never_blocking_execute"` or `"never_blocking_continuation_execute"` or `"always_blocking_execute"` |
 
 #### Semantics of execution functions
 
@@ -367,8 +421,9 @@ The parameters of the execution function and semantics that apply to the the exe
 
 The blocking semantics of an execution function may be one of the following:
 
-* *Potentially blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having potentially blocking semantics are named `execute`.
-* *Non-blocking:* The execution function shall not block the caller pending completion of the submitted function objects. Execution functions having non-blocking semantics are named `post` or `defer`.
+* *Potentially blocking:* The execution function may block the caller pending completion of the submitted function objects. Execution functions having potentially blocking semantics are named `possibly_blocking_execute`.
+* *Never blocking:* The execution function shall not block the caller pending completion of the submitted function objects. Execution functions having never blocking semantics are named `never_blocking_execute` or `never_blocking_continuation_execute`.
+* *Always blocking:* The execution function must block the caller pending completion of the submitted function object. Execution functions having always blocking semantics are named `always_blocking_execute`.
 
 ##### Requirements on execution functions having potentially blocking semantics
 
@@ -376,24 +431,31 @@ In the Table below, `x` denotes a (possibly const) executor object of type `X` a
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.execute(f, ...)` <br/> `execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `execute`. <br/> <br/> May block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+| `x.possibly_blocking_execute(f, ...)` <br/> `possibly_blocking_execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `possibly_blocking_execute`. <br/> <br/> May block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `possibly_blocking_execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
 
-##### Requirements on execution functions having non-blocking semantics
+##### Requirements on execution functions having never blocking semantics
 
 In the Table below, `x` denotes a (possibly const) executor object of type `X` and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.post(f, ...)` <br/>`post(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `post`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
-| `x.defer(f, ...)` <br/>`defer(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `defer`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+| `x.never_blocking_execute(f, ...)` <br/>`never_blocking_execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `never_blocking_execute`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `never_blocking_execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+| `x.never_blocking_continuation_execute(f, ...)` <br/>`never_blocking_continuation_execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `never_blocking_continuation_execute`. <br/> <br/> Shall not block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `never_blocking_continuation_execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
+
+##### Requirements on execution functions having always blocking semantics
+
+In the Table below, `x` denotes a (possibly const) executor object of type `X` and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
+
+| Expression | Return Type | Operational semantics |
+|------------|-------------|---------------------- |
+| `x.always_blocking_execute(f, ...)` <br/> `always_blocking_execute(x, f, ...)` | void | Creates an execution agent with forward progress guarantees of `executor_execution_mapping_category_t<X>` which invokes `DECAY_COPY( std::forward<F>(f))()` at most once, with the call to `DECAY_COPY` being evaluated in the thread that called `always_blocking_execute`. <br/> <br/> Must block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. <br/> <br/> The invocation of `alwaysblocking_execute` synchronizes with (C++Std [intro.multithread]) the invocation of `f`. |
 
 #### Directionality
 
 The directionality property of an execution function may be one of the following:
 
 * *One-way:* The execution function creates execution agents without a channel for awaiting the completion of a submitted function object or for obtaining its result. *Note:* That is, the executor provides fire-and-forget semantics. *--end note*] The names of execution functions having one-way directionality do not have an associated prefix.
-* *Synchronous two-way:* The execution function blocks until execution of the submitted function is complete, and returns the result. The names of execution functions having synchronous two-way directionality have the prefix `sync_`.
-* *Asynchronous two-way:* The execution function returns a `Future` for awaiting the completion of a submitted function object and obtaining its result. The names of execution functions having asynchronous two-way directionality have the prefix `async_` or `then_`.
+* *Two-way:* The execution function returns a `Future` for awaiting the completion of a submitted function object and obtaining its result. The names of execution functions having asynchronous two-way directionality have the prefix `twoway_` or `twoway_then_`.
 
 ##### Requirements on execution functions of one-way directionality
 
@@ -403,22 +465,14 @@ In the Table below, `x` denotes a (possibly const) executor object of type `X`, 
 |------------|-------------|---------------------- |
 | `x.'e'(...)` <br/> `'e'(x, ...)` | void | [*Note:* If `f()` exits via an exception, the behavior is specific to the executor. *--end note.*] |
 
-##### Requirements on execution functions of synchronous two-way directionality
-
-In the Table below, `x` denotes a (possibly const) executor object of type `X`, `'e'` denotes an expression from the requirements on blocking semantics and `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements.
-
-| Expression | Return Type | Operational semantics |
-|------------|-------------|---------------------- |
-| `x.sync_'e'(...)` <br/> `sync_'e'(x, ...)` | `R` | Returns the result of `f()`. <br/><br/> Throws any exception thrown by `f()`. <br/> <br/> Must block forward progress of the caller until `DECAY_COPY( std::forward<F>(f))()` finishes execution. |
-
-##### Requirements on execution functions of asynchronous two-way directionality
+##### Requirements on execution functions of two-way directionality
 
 In the Table below, `x` denotes a (possibly const) executor object of type `X`, `'e'` denotes an expression from the requirements on blocking semantics, `f` denotes a function object of type `F&&` callable as `DECAY_COPY(std::forward<F>(f))()` and where `decay_t<F>` satisfies the `MoveConstructible` requirements and `pred` denotes a `Future` object whose result is `pr`.
 
 | Expression | Return Type | Operational semantics |
 |------------|-------------|---------------------- |
-| `x.async_'e'(...)` <br/> `async_'e'(x, ...)` | A type that satisfies the `Future` requirements for the value type `R`. |  Stores the result of `f()`, or any exception thrown by `f()`, in the associated shared state of the resulting `Future`. |
-| `x.then_'e'(..., pred, ...)` <br/> `then_'e'(x, ..., pred, ...)` | A type that satisfies the `Future` requirements for the value type `R`. | Stores the result of `f(pr)`, or any exception thrown by `f(pr)`, in the associated shared state of the resulting `Future`. |
+| `x.twoway_'e'(...)` <br/> `twoway_'e'(x, ...)` | A type that satisfies the `Future` requirements for the value type `R`. |  Stores the result of `f()`, or any exception thrown by `f()`, in the associated shared state of the resulting `Future`. |
+| `x.twoway_then_'e'(..., pred, ...)` <br/> `twoway_then_'e'(x, ..., pred, ...)` | A type that satisfies the `Future` requirements for the value type `R`. | Stores the result of `f(pr)`, or any exception thrown by `f(pr)`, in the associated shared state of the resulting `Future`. |
 
 #### Cardinality
 
@@ -461,18 +515,18 @@ The table below describes the execution member functions and non-member function
 
 | Cardinality | Directionality | Blocking semantics | Member function | Free function |
 | ------------ | -------------- | --------------------- | ------------------- | ---------------------- |
-| Single | One-way | Potentially blocking | `x.execute(f)` <br/> `x.execute(f, a)` | `execute(x, f)` <br/> `execute(x, f, a)` |
-| Single | One-way | Non-blocking | `x.post(f)` <br/> `x.post(f, a)` <br/> `x.defer(f)`  <br/> `x.defer(f, a)` | `post(x, f)` <br/> `post(x, f, a)` <br/> `defer(x, f)`  <br/> `defer(x, f, a)` |
-| Single | Two-way synchronous | Potentially blocking | `x.sync_execute(f)` <br/> `x.sync_execute(f, a)` | `sync_execute(x, f)` <br/> `sync_execute(x, f, a)` |
-| Single | Two-way synchronous | Non-blocking | NA | NA |
-| Single | Two-way asynchronous | Potentially blocking | `x.async_execute(f)` <br/> `x.async_execute(f, a)`  <br/> `x.then_execute(f, pred)` <br/> `x.then_execute(f, pred, a)` | `async_execute(x, f)` <br/> `async_execute(x, f, a)`  <br/> `then_execute(x, f, pred)` <br/> `then_execute(x, f, pred, a)` |
-| Single | Two-way asynchronous | Non-blocking | `x.async_post(f)` <br/> `x.async_post(f, a)` <br/> `x.async_defer(f)` <br/> `x.async_defer(f, a)` | `async_post(x, f)` <br/> `x.async_post(x, f, a)` <br/> `async_defer(x, f)` <br/> `x.async_defer(x, f, a)` |
-| Bulk | One-way | Potentially blocking | `x.bulk_execute(f, n, sf)` | `bulk_execute(x, f, n, sf)` |
-| Bulk | One-way | Non-blocking | `x.bulk_post(f, n, sf)` <br/> `x.bulk_defer(f, n, sf)` | `bulk_post(x, f, n, sf)` <br/> `bulk_defer(x, f, n, sf)` |
-| Bulk | Two-way synchronous | Potentially blocking | `x.bulk_sync_execute(f, n, rf, sf)` | `bulk_sync_execute(x, f, n, rf, sf)` |
-| Bulk | Two-way synchronous | Non-blocking | NA | NA |
-| Bulk | Two-way asynchronous | Potentially blocking | `x.bulk_async_execute(f, n, rf, sf)` <br/> `x.bulk_then_execute(f, n, pred, rf, sf)` | `bulk_async_execute(x, f, n, rf, sf)` <br/> `bulk_then_execute(x, f, n, pred, rf, sf)` |
-| Bulk | Two-way asynchronous | Non-blocking |  `x.bulk_async_post(f, n, rf, sf)` <br/> `x.bulk_async_defer(f, n, rf, sf)` | `bulk_async_post(x, f, n, rf, sf)` <br/> `bulk_async_defer(x, f, n, rf, sf)` |
+| Single | One-way | Possibly blocking | `x.possibly_blocking(f)` <br/> `x.possibly_blocking(f, a)` | `possibly_blocking(x, f)` <br/> `possibly_blocking(x, f, a)` |
+| Single | One-way | Never blocking | `x.never_blocking__execute(f)` <br/> `x.never_blocking_execute(f, a)` <br/> `x.never_blocking_continuation_execute(f)`  <br/> `x.never_blocking_continuation_execute(f, a)` | `never_blocking_execute(x, f)` <br/> `never_blocking_execute(x, f, a)` <br/> `never_blocking_continuation_execute(x, f)`  <br/> `never_blocking_continuation_execute(x, f, a)` |
+| Single | One-way | Always blocking | `x.always_blocking_execute(f)` <br/> `x.always_blocking_execute(f, a)` | `always_blocking_execute(x, f)` <br/> `always_blocking_execute(x, f, a)` |
+| Single | Two-way | Possibly blocking | `x.twoway_possibly_blocking(f)` <br/> `x.twoway_possibly_blocking(f, a)`  <br/> `x.twoway_then_possibly_blocking(f, pred)` <br/> `x.twoway_then_possibly_blocking(f, pred, a)` | `twoway_possibly_blocking(x, f)` <br/> `twoway_possibly_blocking(x, f, a)`  <br/> `twoway_then_possibly_blocking(x, f, pred)` <br/> `twoway_then_possibly_blocking(x, f, pred, a)` |
+| Single | Two-way | Never blocking | `x.twoway_never_blocking_execute(f)` <br/> `x.twoway_never_blocking_execute(f, a)` <br/> `x.twoway_never_blocking_continuation_execute(f)` <br/> `x.twoway_never_blocking_continuation_execute(f, a)` | `twoway_never_blocking_execute(x, f)` <br/> `x.twoway_never_blocking_execute(x, f, a)` <br/> `twoway_never_blocking_continuation_execute(x, f)` <br/> `x.twoway_never_blocking_continuation_execute(x, f, a)` |
+| Single | Two-way | Always blocking | `x.twoway_always_blocking_execute(f)` <br/> `x.twoway_always_blocking_execute(f, a)` | `twoway_always_blocking_execute(x, f)` <br/> `twoway_always_blocking_execute(x, f, a)` |
+| Bulk | One-way | Possibly blocking | `x.bulk_possibly_blocking(f, n, sf)` | `bulk_possibly_blocking(x, f, n, sf)` |
+| Bulk | One-way | Never blocking | `x.bulk_never_blocking_execute(f, n, sf)` <br/> `x.bulk_never_blocking_continuation_execute(f, n, sf)` | `bulk_never_blocking_execute(x, f, n, sf)` <br/> `bulk_never_blocking_continuation_execute(x, f, n, sf)` |
+| Bulk | One-way | Always blocking | `x.bulk_always_blocking_execute(f, n, sf)` | `bulk_always_blocking_execute(x, f, n, sf)` |
+| Bulk | Two-way | Possibly blocking | `x.bulk_twoway_possibly_blocking(f, n, rf, sf)` <br/> `x.bulk_twoway_then_possibly_blocking(f, n, pred, rf, sf)` | `bulk_twoway_possibly_blocking(x, f, n, rf, sf)` <br/> `bulk_twoway_then_possibly_blocking(x, f, n, pred, rf, sf)` |
+| Bulk | Two-way | Never blocking |  `x.bulk_twoway_never_blocking_execute(f, n, rf, sf)` <br/> `x.bulk_twoway_never_blocking_continuation_execute(f, n, rf, sf)` | `bulk_twoway_never_blocking_execute(x, f, n, rf, sf)` <br/> `bulk_twoway_never_blocking_continuation_execute(x, f, n, rf, sf)` |
+| Bulk | Two-way | Always blocking | `x.bulk_twoway_always_blocking_execute(f, n, rf, sf)` | `bulk_twoway_always_blocking_execute(x, f, n, rf, sf)` |
 
 ### `BaseExecutor` requirements
 
@@ -500,13 +554,19 @@ Table: (Base executor requirements) \label{base_executor_requirements}
 
 The `OneWayExecutor` requirements specify requirements for executors which create execution agents without a channel for awaiting the completion of a submitted function object and obtaining its result. [*Note:* That is, the executor provides fire-and-forget semantics. *--end note*]
 
-A type `X` satisfies the `OneWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, and `can_execute_v<X>` is true.
+A type `X` satisfies the `OneWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, and `can_possibly_blocking_execute_v<X>` is true.
 
-### `NonBlockingOneWayExecutor` requirements
+### `NeverBlockingOneWayExecutor` requirements
 
-The `NonBlockingOneWayExecutor` requirements refine the `OneWayExecutor` requirements by adding one-way operations that are guaranteed not to block the caller pending completion of submitted function objects.
+The `NeverBlockingOneWayExecutor` requirements refine the `OneWayExecutor` requirements by adding one-way operations that are guaranteed not to block the caller pending completion of submitted function objects.
 
-A type `X` satisfies the `NonBlockingOneWayExecutor` requirements if it satisfies the `OneWayExecutor` requirements, `can_post_v<X>` is true, and `can_defer_v<X>` is true.
+A type `X` satisfies the `NeverBlockingOneWayExecutor` requirements if it satisfies the `OneWayExecutor` requirements, `can_never_blocking_execute_v<X>` is true, and `can_never_blocking_continuation_execute_v<X>` is true.
+
+### `AlwaysBlockingOneWayExecutor` requirements
+
+The `AlwaysBlockingOneWayExecutor` requirements refine the `OneWayExecutor` requirements by adding one-way operations that are guaranteed to always block the caller pending completion of submitted function objects.
+
+A type `X` satisfies the `AlwaysBlockingOneWayExecutor` requirements if it satisfies the `OneWayExecutor` requirements, `can_always_blocking_execute_v<X>` is true.
 
 ### `TwoWayExecutor` requirements
 
@@ -514,7 +574,17 @@ The `TwoWayExecutor` requirements specify requirements for executors which
 creating execution agents with a channel for awaiting the completion of a
 submitted function object and obtaining its result.
 
-A type `X` satisfies the `TwoWayExecutor` requirements if it satisfies the `BaseExecutor` requirements, `can_sync_execute_v<X>` is true, and `can_async_execute_v<X>` is true.
+### `NeverBlockingTwoWayExecutor` requirements
+
+The `NeverBlockingTwoWayExecutor` requirements refine the `TwoWayExecutor` requirements by adding two-way operations that are guaranteed not to block the caller pending completion of submitted function objects.
+
+A type `X` satisfies the `NeverBlockingTwoWayExecutor` requirements if it satisfies the `TwoWayExecutor` requirements, `can_twoway_never_blocking_execute_v<X>` is true, and `can_twoway_never_blocking_continuation_execute_v<X>` is true.
+
+### `AlwaysBlockingTwoWayExecutor` requirements
+
+The `AlwaysBlockingTwoWayExecutor` requirements refine the `TwoWayExecutor` requirements by adding two-way operations that are guaranteed to always block the caller pending completion of submitted function objects.
+
+A type `X` satisfies the `AlwaysBlockingTwoWayExecutor` requirements if it satisfies the `TwoWayExecutor` requirements, `can_twoway_always_blocking_execute_v<X>` is true.
 
 ### `BulkTwoWayExecutor` requirements
 
@@ -546,83 +616,91 @@ Table: (Executor Work Tracker requirements) \label{executor_work_tracker_require
 
 ### Member detection type traits
 
-    template<class T> struct has_execute_member;
-    template<class T> struct has_post_member;
-    template<class T> struct has_defer_member;
-    template<class T> struct has_sync_execute_member;
-    template<class T> struct has_async_execute_member;
-    template<class T> struct has_async_post_member;
-    template<class T> struct has_async_defer_member;
-    template<class T> struct has_then_execute_member;
-    template<class T> struct has_bulk_execute_member;
-    template<class T> struct has_bulk_post_member;
-    template<class T> struct has_bulk_defer_member;
-    template<class T> struct has_bulk_sync_execute_member;
-    template<class T> struct has_bulk_async_execute_member;
-    template<class T> struct has_bulk_async_post_member;
-    template<class T> struct has_bulk_async_defer_member;
-    template<class T> struct has_bulk_then_execute_member;
+    template<class T> struct has_possibly_blocking_execute_member;
+    template<class T> struct has_never_blocking_execute_member;
+    template<class T> struct has_never_blocking_continuation_execute_member;
+    template<class T> struct has_always_blocking_execute_member;
+    template<class T> struct has_twoway_possibly_blocking_execute_member;
+    template<class T> struct has_twoway_never_blocking_execute_member;
+    template<class T> struct has_twoway_never_blocking_continuation_execute_member;
+    template<class T> struct has_twoway_always_blocking_execute_member;
+    template<class T> struct has_twoway_then_possibly_blocking_execute_member;
+    template<class T> struct has_bulk_possibly_blocking_execute_member;
+    template<class T> struct has_bulk_never_blocking_execute_member;
+    template<class T> struct has_bulk_never_blocking_continuation_execute_member;
+    template<class T> struct has_bulk_always_blocking_execute_member;
+    template<class T> struct has_bulk_twoway_possibly_blocking_execute_member;
+    template<class T> struct has_bulk_twoway_never_blocking_execute_member;
+    template<class T> struct has_bulk_twoway_never_blocking_continuation_execute_member;
+    template<class T> struct has_bulk_twoway_always_blocking_execute_member;
+    template<class T> struct has_bulk_twoway_then_possibly_blocking_execute_member;
 
 This sub-clause contains templates that may be used to query the properties of a type at compile time. Each of these templates is a UnaryTypeTrait (C++Std [meta.rqmts]) with a BaseCharacteristic of `true_type` if the corresponding condition is true, otherwise `false_type`.
 
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/>`struct has_execute_member` | `T` has a member function named `execute` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_post_member` | `T` has a member function named `post` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_defer_member` | `T` has a member function named `defer` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_sync_execute_member` | `T` has a member function named `sync_execute` that satisfies the syntactic requirements of a synchronous two-way execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_execute_member` | `T` has a member function named `async_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_post_member` | `T` has a member function named `async_post` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_defer_member` | `T` has a member function named `async_defer` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_then_execute_member` | `T` has a member function named `then_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_execute_member` | `T` has a member function named `bulk_execute` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_post_member` | `T` has a member function named `bulk_post` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_defer_member` | `T` has a member function named `bulk_defer` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_sync_execute_member` | `T` has a member function named `bulk_sync_execute` that satisfies the syntactic requirements of a synchronous two-way execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_execute_member` | `T` has a member function named `bulk_async_execute` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_post_member` | `T` has a member function named `bulk_async_post` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_defer_member` | `T` has a member function named `bulk_async_defer` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_then_execute_member` | `T` has a member function named `bulk_then_execute` that satisfies the syntactic requirements of an a asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_possibly_blocking_execute_member` | `T` has a member function named `possibly_blocking_execute` that satisfies the syntactic requirements of a one-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_never_blocking_execute_member` | `T` has a member function named `never_blocking_execute` that satisfies the syntactic requirements of a one-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_never_blocking_continuation_execute_member` | `T` has a member function named `never_blocking_continuation_execute` that satisfies the syntactic requirements of a one-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_always_blocking_execute_member` | `T` has a member function named `always_blocking_execute` that satisfies the syntactic requirements of a one-way, always blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_possibly_blocking_execute_member` | `T` has a member function named `twoway_possibly_blocking_execute` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_never_blocking_execute_member` | `T` has a member function named `twoway_never_blocking_execute` that satisfies the syntactic requirements of a two-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_never_blocking_continuation_execute_member` | `T` has a member function named `twoway_never_blocking_continuation_execute` that satisfies the syntactic requirements of a two-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_always_blocking_execute_member` | `T` has a member function named `twoway_always_blocking_execute` that satisfies the syntactic requirements of a two-way always blocking two-way execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_then_possibly_blocking_execute_member` | `T` has a member function named `twoway_then_possibly_blocking_execute` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_possibly_blocking_execute_member` | `T` has a member function named `bulk_possibly_blocking_execute` that satisfies the syntactic requirements of a one-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_never_blocking_execute_member` | `T` has a member function named `bulk_never_blocking_execute` that satisfies the syntactic requirements of a one-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_never_blocking_continuation_execute_member` | `T` has a member function named `bulk_never_blocking_continuation_execute` that satisfies the syntactic requirements of a one-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_always_blocking_execute_member` | `T` has a member function named `bulk_always_blocking_execute` that satisfies the syntactic requirements of a one-way, always blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_possibly_blocking_execute_member` | `T` has a member function named `bulk_twoway_possibly_blocking_execute` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_never_blocking_execute_member` | `T` has a member function named `bulk_twoway_never_blocking_execute` that satisfies the syntactic requirements of a two-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_never_blocking_continuation_execute_member` | `T` has a member function named `bulk_twoway_never_blocking_continuation_execute` that satisfies the syntactic requirements of a two-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_always_blocking_execute_member` | `T` has a member function named `bulk_twoway_always_blocking_execute` that satisfies the syntactic requirements of a two-way, always blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_then_possibly_blocking_execute_member` | `T` has a member function named `bulk_twoway_then_possibly_blocking_execute` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
 
 ### Free function detection type traits
 
-    template<class T> struct has_execute_free_function;
-    template<class T> struct has_post_free_function;
-    template<class T> struct has_defer_free_function;
-    template<class T> struct has_sync_execute_free_function;
-    template<class T> struct has_async_execute_free_function;
-    template<class T> struct has_async_post_free_function;
-    template<class T> struct has_async_defer_free_function;
-    template<class T> struct has_then_execute_free_function;
-    template<class T> struct has_bulk_execute_free_function;
-    template<class T> struct has_bulk_post_free_function;
-    template<class T> struct has_bulk_defer_free_function;
-    template<class T> struct has_bulk_sync_execute_free_function;
-    template<class T> struct has_bulk_async_execute_free_function;
-    template<class T> struct has_bulk_async_post_free_function;
-    template<class T> struct has_bulk_async_defer_free_function;
-    template<class T> struct has_bulk_then_execute_free_function;
+    template<class T> struct has_possibly_blocking_execute_free_function;
+    template<class T> struct has_never_blocking_execute_free_function;
+    template<class T> struct has_never_blocking_continuation_execute_free_function;
+    template<class T> struct has_always_blocking_execute_free_function;
+    template<class T> struct has_twoway_possibly_blocking_execute_free_function;
+    template<class T> struct has_twoway_never_blocking_execute_free_function;
+    template<class T> struct has_twoway_never_blocking_continuation_execute_free_function;
+    template<class T> struct has_twoway_always_blocking_execute_free_function;
+    template<class T> struct has_twoway_then_possibly_blocking_execute_free_function;
+    template<class T> struct has_bulk_possibly_blocking_execute_free_function;
+    template<class T> struct has_bulk_never_blocking_execute_free_function;
+    template<class T> struct has_bulk_never_blocking_continuation_execute_free_function;
+    template<class T> struct has_bulk_always_blocking_execute_free_function;
+    template<class T> struct has_bulk_twoway_possibly_blocking_execute_free_function;
+    template<class T> struct has_bulk_twoway_never_blocking_execute_free_function;
+    template<class T> struct has_bulk_twoway_never_blocking_continuation_execute_free_function;
+    template<class T> struct has_bulk_twoway_always_blocking_execute_free_function;
+    template<class T> struct has_bulk_twoway_then_possibly_blocking_execute_free_function;
 
 This sub-clause contains templates that may be used to query the properties of a type at compile time. Each of these templates is a UnaryTypeTrait (C++Std [meta.rqmts]) with a BaseCharacteristic of `true_type` if the corresponding condition is true, otherwise `false_type`.
 
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/>`struct has_execute_free_function` | There exists a free function named `execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_post_free_function` | There exists a free function named `post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_defer_free_function` | There exists a free function named `defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_sync_execute_free_function` | There exists a free function named `sync_execute` taking an executor of type `T` that satisfies the syntactic requirements of a synchronous two-way execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_execute_free_function` | There exists a free function named `async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_post_free_function` | There exists a free function named `async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_async_defer_free_function` | There exists a free function named `async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_then_execute_free_function` | There exists a free function named `then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of single cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_execute_free_function` | There exists a free function named `bulk_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_post_free_function` | There exists a free function named `bulk_post` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_defer_free_function` | There exists a free function named `bulk_defer` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_sync_execute_free_function` | There exists a free function named `bulk_sync_execute` taking an executor of type `T` that satisfies the syntactic requirements of a synchronous two-way execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_execute_free_function` | There exists a free function named `bulk_async_execute` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_post_free_function` | There exists a free function named `bulk_async_post` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_async_defer_free_function` | There exists a free function named `bulk_async_defer` taking an executor of type `T` that satisfies the syntactic requirements of an asynchronous two-way, non-blocking execution function of bulk cardinality. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_bulk_then_execute_free_function` | There exists a free function named `bulk_then_execute` taking an executor of type `T` that satisfies the syntactic requirements of an an asynchronous two-way, potentially blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_possibly_blocking_execute_free_function` | There exists a free function named `possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_never_blocking_execute_free_function` | There exists a free function named `never_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_never_blocking_continuation_execute_free_function` | There exists a free function named `never_blocking_continuation_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_always_blocking_execute_free_function` | There exists a free function named `always_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, always blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_possibly_blocking_execute_free_function` | There exists a free function named `twoway_possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_never_blocking_execute_free_function` | There exists a free function named `twoway_never_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_never_blocking_continuation_execute_free_function` | There exists a free function named `twoway_never_blocking_continuation_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, never blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_always_blocking_execute_free_function` | There exists a free function named `twoway_always_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, always blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_twoway_then_possibly_blocking_execute_free_function` | There exists a free function named `twoway_then_possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of single cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_possibly_blocking_execute_free_function` | There exists a free function named `bulk_possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_never_blocking_execute_free_function` | There exists a free function named `bulk_never_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_never_blocking_continuation_execute_free_function` | There exists a free function named `bulk_never_blocking_continuation_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_always_blocking_execute_free_function` | There exists a free function named `bulk_always_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a one-way, always blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_possibly_blocking_execute_free_function` | There exists a free function named `bulk_twoway_possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_never_blocking_execute_free_function` | There exists a free function named `bulk_twoway_never_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_never_blocking_continuation_execute_free_function` | There exists a free function named `bulk_twoway_never_blocking_continuation_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, never blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_always_blocking_execute_free_function` | There exists a free function named `bulk_twoway_always_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of a two-way, always blocking execution function of bulk cardinality. | `T` is a complete type. |
+| `template<class T>` <br/>`struct has_bulk_twoway_then_possibly_blocking_execute_free_function` | There exists a free function named `bulk_twoway_then_possibly_blocking_execute` taking an executor of type `T` that satisfies the syntactic requirements of an a two-way, possibly blocking execution function of bulk cardinality. | `T` is a complete type. |
 
 ## Executor customization points
 

--- a/wording.md
+++ b/wording.md
@@ -411,19 +411,21 @@ where `x` denotes an executor object, `e` denotes the function name and `...` de
 
 Each execution function is made up from a combination of three properties: its **blocking semantics**, **directionality**, and **cardinality**. The combination of these properties determines the execution function's name, parameters, and semantics.
 
-#### Naming of execution functions
-
-The name of an execution function is determined by the combination of its properties. A word or prefix is associated with each property, and these are concatenated in the order below.
-
-| Cardinality | Directionality | Blocking semantics |
-|-------------|----------------|--------------------|
-| `""` or `"bulk_"` | `""` or `"twoway_"` or `"twoway_then_"` | `"possibly_blocking_execute"` or `"never_blocking_execute"` or `"never_blocking_continuation_execute"` or `"always_blocking_execute"` |
-
 #### Semantics of execution functions
 
 The parameters of the execution function and semantics that apply to the the execution function and to the execution agents created by it are determined by the combination of its properties. Parameters and semantics are added to an execution function for each of the properties. Whenever there is a conflict of semantics the presedence is resolved in the order below.
 
     Cardinality > Directionality > Blocking semantics
+
+#### Naming of execution functions and customization points
+
+The name of an execution function and it's respective customization point is determined by the combination of its properties. A word or prefix is associated with each property, and these are concatenated in the order below.
+
+| Cardinality | Directionality | Blocking semantics |
+|-------------|----------------|--------------------|
+| `""` or `"bulk_"` | `""` or `"twoway_"` or `"twoway_then_"` | `"possibly_blocking_execute"` or `"never_blocking_execute"` or `"never_blocking_continuation_execute"` or `"always_blocking_execute"` |
+
+[*Note:* For the purposes of clarity the naming of execution functions and customization points have been named using a particularly verbose naming scheme. The aim of this naming scheme is to make the semantics of each function clearer, we intend for these names to replaced a another naming scheme at a later date.  *--end note.*]
 
 #### Blocking semantics
 


### PR DESCRIPTION
* Add new trait `is_always_blocking_one_way_executor`.
* Add fix for typos `can_post_execute` and `can_defer_execute`.
* Add one-way always blocking execution function variants.
* Change `async_` to `twoway_`.
* Change `then_` to `twoway_then_`.
* Change `execute` to `possibly_blocking_execute`.
* Change `post` to `never_blocking_execute`.
* Change `defer` to `never_blocking_continuation_execute`.
* Change `invoke` to `always_blocking_execute`.
* Add `TwoWayNeverBLocking` and `TwoWayAlwaysBlocking` execution categories.
* Add section in properties description for always blocking properties.
* Remove `sync_execute` from properties descriptions.
* Add wording for `always_blocking_execute` and
`bulk_always_blocking_execute`.
* Update the naming scheme of execution functions.
* Alter table so it shows all combinations of properties.
* Add section for justifying having `always_blocking_execute`.
* Add section for justifying having `bulk_always_blocking_execute`.
* Add note to the wording and exaplanitory document regarding the naming
scheme.

Fix for #190 & #161 