### PR TITLE
Change discussing default constructor for static_thread_pool

### DIFF
--- a/explanatory.md
+++ b/explanatory.md
@@ -1846,16 +1846,23 @@ object, and synchronous two-way functions will simply throw any exceptions they
 encounter as normal. However, it is not clear what mechanism, if any, one-way
 execution functions should use for error reporting.
 
-### Additional Thread Pool Types
+### Thread Pool Variations
 
 Our proposal specifies a single thread pool type, `static_thread_pool`, which
 represents a simple thread pool which assumes that the creator knows the
 correct thread count for the use case. As a result, it assumes a pre-determined
-sizing and does not automatically resize itself. We recognize that alternative
-approaches serving other use cases exist and anticipate additional thread pool
-proposals. In particular, we are aware of a separate effort which will propose
-an additional thread pool type, `dynamic_thread_pool`, and we expect this type
-of thread pool to be both dynamically and automatically resizable.
+sizing and does not automatically resize itself and has no default size.
+
+There exist heuristics for right-sizing a thread pool (both statically
+determined like 2*hardware_concurrency, as well as dynamically adjusted), but
+these are considered to be out of scope of this proposal as a reasonable size
+pool is specific to the application and hardware.
+
+We recognize that alternative approaches serving other use cases exist and
+anticipate additional thread pool proposals. In particular, we are aware of a
+separate effort which will propose an additional thread pool type,
+`dynamic_thread_pool`, and we expect this type of thread pool to be both
+dynamically and automatically resizable.
 
 ### Execution Resources
 

--- a/explanatory.md
+++ b/explanatory.md
@@ -1849,12 +1849,13 @@ execution functions should use for error reporting.
 ### Additional Thread Pool Types
 
 Our proposal specifies a single thread pool type, `static_thread_pool`, which
-represents a simple thread pool which does not automatically resize itself. We
-recognize that alternative approaches serving other use cases exist and
-anticipate additional thread pool proposals. In particular, we are aware of a
-separate effort which will propose an additional thread pool type,
-         `dynamic_thread_pool`, and we expect this type of thread pool to be
-         both dynamically and automatically resizable.
+represents a simple thread pool which assumes that the creator knows the
+correct thread count for the use case. As a result, it assumes a pre-determined
+sizing and does not automatically resize itself. We recognize that alternative
+approaches serving other use cases exist and anticipate additional thread pool
+proposals. In particular, we are aware of a separate effort which will propose
+an additional thread pool type, `dynamic_thread_pool`, and we expect this type
+of thread pool to be both dynamically and automatically resizable.
 
 ### Execution Resources
 

--- a/wording.md
+++ b/wording.md
@@ -1657,9 +1657,8 @@ inline namespace concurrency_v2 {
 `static_thread_pool` is a statically-sized thread pool which may be explicitly
 grown via thread attachment. The `static_thread_pool` is expected to be created
 with the use case clearly in mind with the number of threads known by the
-creator. Common patterns for deciding on correctly sizing a thread pool exist.
-As a result, no default constructor is considered correct for arbitrary use
-cases. Additionally, `static_thread_pool` does not support any form of
+creator. As a result, no default constructor is considered correct for
+arbitrary use cases and `static_thread_pool` does not support any form of
 automatic resizing.   
 
 `static_thread_pool` presents an effectively unbounded input queue and the execution functions of `static_thread_pool`'s associated executors do not block on this input queue.

--- a/wording.md
+++ b/wording.md
@@ -1655,8 +1655,12 @@ inline namespace concurrency_v2 {
 ### Class `static_thread_pool`
 
 `static_thread_pool` is a statically-sized thread pool which may be explicitly
-grown via thread attachment. However, `static_thread_pool` does not
-automatically change size. 
+grown via thread attachment. The `static_thread_pool` is expected to be created
+with the use case clearly in mind with the number of threads known by the
+creator. Common patterns for deciding on correctly sizing a thread pool exist.
+As a result, no default constructor is considered correct for arbitrary use
+cases. Additionally, `static_thread_pool` does not support any form of
+automatic resizing.   
 
 `static_thread_pool` presents an effectively unbounded input queue and the execution functions of `static_thread_pool`'s associated executors do not block on this input queue.
 


### PR DESCRIPTION
Resolves #158 by adding wording around the rationale for no default constructor for the static_thread_pool.