### PR TITLE
Work-in-progress: invoke & for_each examples

### DIFF
--- a/rebind_prototype/examples/for_each/Makefile
+++ b/rebind_prototype/examples/for_each/Makefile
@@ -1,0 +1,14 @@
+EXAMPLES = \
+	for_each_1
+
+CXXFLAGS = -std=c++14 -pthread -Wall -Wextra -I../../include
+
+.PHONY: all clean
+
+all: $(EXAMPLES)
+
+clean:
+	rm -f $(EXAMPLES)
+
+$(EXAMPLES): %: %.cpp
+	$(CXX) $(CXXFLAGS) -o$@ $<

--- a/rebind_prototype/examples/for_each/for_each_1.cpp
+++ b/rebind_prototype/examples/for_each/for_each_1.cpp
@@ -1,0 +1,139 @@
+#include <experimental/thread_pool>
+#include <experimental/execution>
+#include <vector>
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+
+namespace execution = std::experimental::execution;
+using std::experimental::static_thread_pool;
+
+namespace impl
+{
+
+static_thread_pool system_thread_pool{std::max(1u,std::thread::hardware_concurrency())};
+
+class system_thread_pool_bulk_executor
+{
+  public:
+    using bulk_forward_progress_guarantee = execution::executor_bulk_forward_progress_guarantee_t<static_thread_pool::executor_type>;
+    using shape_type = execution::executor_shape_t<static_thread_pool::executor_type>;
+    using index_type = execution::executor_index_t<static_thread_pool::executor_type>;
+
+    template<class T>
+    using future = execution::executor_future_t<static_thread_pool::executor_type,T>;
+
+    template<class Function, class ResultFactory, class SharedFactory>
+    auto operator()(Function f, size_t n, ResultFactory rf, SharedFactory sf) const
+    {
+      return system_thread_pool_bulk_executor()(f, n, rf, sf);
+    }
+
+    template<class Function, class SharedFactory>
+    auto operator()(Function f, size_t n, SharedFactory sf) const
+    {
+      return system_thread_pool_bulk_executor()(f, n, sf);
+    }
+
+    template<class Function>
+    auto operator()(Function f) const
+    {
+      return system_thread_pool_bulk_executor()(f);
+    }
+};
+
+template<class BulkForwardProgressRequirement, class Executor>
+class basic_execution_policy
+{
+  public:
+    //static_assert(is_weaker_than<
+    //                BulkForwardProgressRequirement,
+    //                executor_bulk_forward_progress_guarantee_t<Executor>
+    //              >::value,
+    //              "basic_execution_policy: BulkForwardProgressRequirement cannot be satisfied by Executor's guarantee."
+    //);
+
+    using executor_type = Executor;
+    using bulk_forward_progress_requirement = BulkForwardProgressRequirement;
+
+    basic_execution_policy() = default;
+
+    basic_execution_policy(const basic_execution_policy&) = default;
+
+    basic_execution_policy(executor_type&& exec)
+      : executor_(std::move(exec))
+    {}
+
+    basic_execution_policy(const executor_type& exec)
+      : executor_(exec)
+    {}
+
+    template<class OtherExecutor
+             //, class = typename std::enable_if<
+             //  is_weaker_than<
+             //    BulkForwardProgressRequirement,
+             //    executor_bulk_forward_progress_guarantee_t<typename std::decay<OtherExecutor>::type>
+             //  >::value
+             //>::type
+            >
+    basic_execution_policy<BulkForwardProgressRequirement,OtherExecutor> on(OtherExecutor&& exec) const
+    {
+      return basic_execution_policy<BulkForwardProgressRequirement,OtherExecutor>(std::forward<OtherExecutor>(exec));
+    }
+
+    executor_type executor() const
+    {
+      return executor_;
+    }
+
+  private:
+    executor_type executor_;
+};
+
+constexpr struct ignored {} ignore;
+
+} // end impl
+
+class parallel_policy : public impl::basic_execution_policy<execution::bulk_parallel_execution, impl::system_thread_pool_bulk_executor>
+{
+  using super_t = impl::basic_execution_policy<execution::bulk_parallel_execution, impl::system_thread_pool_bulk_executor>;
+
+  public:
+    using super_t::super_t;
+};
+
+constexpr parallel_policy par{};
+
+template<class ExecutionPolicy, class RandomAccessIterator, class Function>
+void for_each(ExecutionPolicy&& policy, RandomAccessIterator first, RandomAccessIterator last, Function f)
+{
+  auto n = last - first;
+
+  // XXX this should be a two-way executor so that we can handle user exceptions
+  auto always_blocking_one_way_bulk_exec = execution::rebind(execution::rebind(policy.executor(), execution::bulk), execution::always_blocking);
+
+  always_blocking_one_way_bulk_exec([=](size_t idx, impl::ignored&)
+  {
+    f(first[idx]);
+  },
+  n,
+  []{ return impl::ignore; }
+  );
+}
+
+int main()
+{
+  static_thread_pool pool{1};
+
+  std::vector<int> vec(10);
+
+  for_each(par.on(pool.executor()), vec.begin(), vec.end(), [](int& x)
+  {
+    x = 42;
+  });
+
+  assert(std::count(vec.begin(), vec.end(), 42) == static_cast<int>(vec.size()));
+
+  std::cout << "OK" << std::endl;
+}
+

--- a/rebind_prototype/examples/invoke/Makefile
+++ b/rebind_prototype/examples/invoke/Makefile
@@ -1,0 +1,16 @@
+EXAMPLES = \
+	invoke_1 \
+	invoke_2 \
+	invoke_3
+
+CXXFLAGS = -std=c++14 -pthread -Wall -Wextra -I../../include
+
+.PHONY: all clean
+
+all: $(EXAMPLES)
+
+clean:
+	rm -f $(EXAMPLES)
+
+$(EXAMPLES): %: %.cpp
+	$(CXX) $(CXXFLAGS) -o$@ $<

--- a/rebind_prototype/examples/invoke/invoke_1.cpp
+++ b/rebind_prototype/examples/invoke/invoke_1.cpp
@@ -1,0 +1,23 @@
+#include <experimental/thread_pool>
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+#include <cassert>
+
+namespace execution = std::experimental::execution;
+using std::experimental::static_thread_pool;
+
+template <class Executor, class Function>
+typename std::result_of<Function()>::type invoke(Executor ex, Function&& f)
+{
+  return execution::rebind(execution::rebind(ex, execution::two_way), execution::always_blocking)(std::forward<Function>(f)).get();
+}
+
+int main()
+{
+  static_thread_pool pool{1};
+  int result = invoke(pool.executor(), []{ return 42; });
+  std::cout << "result is " << result << "\n";
+
+  assert(result == 42);
+}

--- a/rebind_prototype/examples/invoke/invoke_2.cpp
+++ b/rebind_prototype/examples/invoke/invoke_2.cpp
@@ -1,0 +1,34 @@
+#include <experimental/thread_pool>
+#include <iostream>
+#include <tuple>
+#include <cassert>
+
+namespace execution = std::experimental::execution;
+using std::experimental::static_thread_pool;
+
+template <class Executor, class Function, class Args, std::size_t... I>
+auto invoke_helper(Executor ex, Function f, Args args, std::index_sequence<I...>)
+{
+  return execution::rebind(execution::rebind(ex, execution::two_way), execution::always_blocking)(
+      [f = std::move(f), args = std::move(args)]() mutable
+      {
+        return f(std::move(std::get<I>(args))...);
+      }).get();
+}
+
+template <class Executor, class Function, class... Args>
+auto invoke(Executor ex, Function f, Args&&... args)
+{
+  return invoke_helper(std::move(ex), std::move(f),
+      std::make_tuple(std::forward<Args>(args)...),
+      std::make_index_sequence<sizeof...(Args)>());
+}
+
+int main()
+{
+  static_thread_pool pool{1};
+  int result = invoke(pool.executor(), [](int i, int j){ return i + j; }, 20, 22);
+  std::cout << "result is " << result << "\n";
+
+  assert(result == 42);
+}

--- a/rebind_prototype/examples/invoke/invoke_3.cpp
+++ b/rebind_prototype/examples/invoke/invoke_3.cpp
@@ -1,0 +1,55 @@
+#include <experimental/thread_pool>
+#include <iostream>
+#include <tuple>
+#include <cassert>
+
+namespace execution = std::experimental::execution;
+using std::experimental::static_thread_pool;
+
+template <class Executor, class Function, class Args, std::size_t... I>
+auto invoke_helper(Executor ex, Function f, Args args, std::index_sequence<I...>)
+{
+  return execution::rebind(execution::rebind(ex, execution::two_way), execution::always_blocking)(
+      [f = std::move(f), args = std::move(args)]() mutable
+      {
+        return f(std::move(std::get<I>(args))...);
+      }).get();
+}
+
+template <class Executor, class Function, class... Args>
+auto invoke(Executor ex, Function f, Args&&... args)
+{
+  return invoke_helper(std::move(ex), std::move(f),
+      std::make_tuple(std::forward<Args>(args)...),
+      std::make_index_sequence<sizeof...(Args)>());
+}
+
+class inline_executor
+{
+public:
+  auto& context() const noexcept { return *this; }
+
+  friend bool operator==(const inline_executor&, const inline_executor&) noexcept
+  {
+    return true;
+  }
+
+  friend bool operator!=(const inline_executor&, const inline_executor&) noexcept
+  {
+    return false;
+  }
+
+  template <class Function>
+  void operator()(Function f) const noexcept
+  {
+    f();
+  }
+};
+
+int main()
+{
+  int result = invoke(inline_executor(), [](int i, int j){ return i + j; }, 20, 22);
+  std::cout << "result is " << result << "\n";
+
+  assert(result == 42);
+}

--- a/rebind_prototype/include/experimental/bits/always_ready_future.h
+++ b/rebind_prototype/include/experimental/bits/always_ready_future.h
@@ -1,0 +1,66 @@
+#ifndef STD_EXPERIMENTAL_BITS_ALWAYS_READY_FUTURE_H
+#define STD_EXPERIMENTAL_BITS_ALWAYS_READY_FUTURE_H
+
+namespace std {
+namespace experimental {
+inline namespace concurrency_v2 {
+namespace execution {
+namespace impl {
+
+template<class T>
+class always_ready_future
+{
+  public:
+    always_ready_future(const T& value) : value_or_exception_(value) {}
+
+    always_ready_future(T&& value) : value_or_exception_(std::move(value)) {}
+    
+    //always_ready_future(std::exception_ptr e) : value_e() {}
+
+    T get()
+    {
+      return std::move(value_or_exception_);
+    }
+
+    void wait() const {}
+
+  private:
+    // XXX should be variant<T,exception_ptr>
+    T value_or_exception_;
+};
+
+template<>
+class always_ready_future<void>
+{
+  public:
+    always_ready_future() {}
+    
+    //always_ready_future(std::exception_ptr e) : maybe_exception_(e) {}
+
+    void get() const {}
+
+    void wait() const {}
+
+  private:
+    // XXX should be optional<exception_ptr>
+};
+
+template<class T>
+always_ready_future<typename std::decay<T>::type> make_always_ready_future(T&& value)
+{
+  return always_ready_future<typename std::decay<T>::type>(std::forward<T>(value));
+}
+
+inline always_ready_future<void> make_always_ready_future()
+{
+  return always_ready_future<void>();
+}
+
+} // namespace impl
+} // namespace execution
+} // inline namespace concurrency_v2
+} // namespace experimental
+} // namespace std
+
+#endif // STD_EXPERIMENTAL_BITS_ALWAYS_READY_FUTURE_H
+

--- a/rebind_prototype/include/experimental/bits/executor_bulk_forward_progress_guarantee.h
+++ b/rebind_prototype/include/experimental/bits/executor_bulk_forward_progress_guarantee.h
@@ -1,0 +1,39 @@
+#ifndef STD_EXPERIMENTAL_BITS_EXECUTOR_BULK_FORWARD_PROGRESS_GUARANTEE_H
+#define STD_EXPERIMENTAL_BITS_EXECUTOR_BULK_FORWARD_PROGRESS_GUARANTEE_H
+
+namespace std {
+namespace experimental {
+inline namespace concurrency_v2 {
+namespace execution {
+namespace executor_bulk_forward_progress_guarantee_impl {
+
+template<class>
+struct type_check
+{
+  typedef void type;
+};
+
+template<class Executor, class = void>
+struct eval
+{
+  using type = bulk_unsequenced_execution;
+};
+
+template<class Executor>
+struct eval<Executor, typename type_check<typename Executor::bulk_forward_progress_guarantee>::type>
+{
+  using type = typename Executor::bulk_forward_progress_guarantee;
+};
+
+} // namespace executor_bulk_forward_progress_guarantee_impl
+
+template<class Executor>
+struct executor_bulk_forward_progress_guarantee : executor_bulk_forward_progress_guarantee_impl::eval<Executor> {};
+
+} // namespace execution
+} // inline namespace concurrency_v2
+} // namespace experimental
+} // namespace std
+
+#endif // STD_EXPERIMENTAL_BITS_EXECUTOR_BULK_FORWARD_PROGRESS_GUARANTEE_H
+

--- a/rebind_prototype/include/experimental/bits/rebind.h
+++ b/rebind_prototype/include/experimental/bits/rebind.h
@@ -13,6 +13,7 @@ namespace execution {
 
 struct one_way_t;
 struct two_way_t;
+struct always_blocking_t;
 struct possibly_blocking_t;
 struct is_continuation_t;
 struct is_not_continuation_t;
@@ -42,6 +43,10 @@ template<class Executor>
   constexpr typename std::enable_if<is_two_way_executor<Executor>::value
     && !has_rebind_member<Executor, two_way_t>::value, Executor>::type
       rebind(Executor ex, two_way_t);
+template<class Executor> class always_blocking_adapter;
+template<class Executor>
+  constexpr typename std::enable_if<!has_rebind_member<Executor, always_blocking_t>::value, always_blocking_adapter<Executor>>::type
+    rebind(Executor ex, always_blocking_t);
 template<class Executor>
   constexpr typename std::enable_if<!has_rebind_member<Executor, possibly_blocking_t>::value, Executor>::type
     rebind(Executor ex, possibly_blocking_t);

--- a/rebind_prototype/include/experimental/bits/rebind_adaptations.h
+++ b/rebind_prototype/include/experimental/bits/rebind_adaptations.h
@@ -2,6 +2,7 @@
 #define STD_EXPERIMENTAL_BITS_REBIND_ADAPTATIONS_H
 
 #include <experimental/bits/rebind_member_result.h>
+#include <experimental/bits/always_ready_future.h>
 #include <future>
 #include <type_traits>
 #include <utility>
@@ -111,7 +112,7 @@ public:
   }
 
   template <class Function>
-  auto operator()(Function f) const -> std::future<decltype(f())>
+  auto operator()(Function f) const -> executor_future_t<PossiblyBlockingExecutor,decltype(f())>
   {
     auto future = two_way_possibly_blocking_ex_(std::move(f));
     future.wait();
@@ -127,12 +128,86 @@ template<class Executor>
   constexpr typename std::enable_if<!has_rebind_member<Executor, always_blocking_t>::value, always_blocking_adapter<Executor>>::type
     rebind(Executor ex, always_blocking_t) { return always_blocking_adapter<Executor>(std::move(ex)); }
     
-
 // Default rebind for possibly blocking does no adaptation, as all executors are possibly blocking.
 
 template<class Executor>
   constexpr typename std::enable_if<!has_rebind_member<Executor, possibly_blocking_t>::value, Executor>::type
     rebind(Executor ex, possibly_blocking_t) { return std::move(ex); }
+
+// Default rebind for bulk adapts single executors, leaves bulk executor as is.
+template<class SingleExecutor>
+class bulk_adapter
+{
+  using executor_type = decltype(execution::rebind(std::declval<SingleExecutor>(), always_blocking));
+  executor_type always_blocking_single_ex_;
+
+public:
+  using bulk_forward_progress_guarantee = bulk_unsequenced_execution;
+
+  template<class T>
+  using future = impl::always_ready_future<T>;
+
+  bulk_adapter(SingleExecutor ex) : always_blocking_single_ex_(execution::rebind(std::declval<SingleExecutor>(), always_blocking)) {}
+
+  SingleExecutor rebind(single_t) const & { return always_blocking_single_ex_; }
+  SingleExecutor rebind(single_t) && { return std::move(always_blocking_single_ex_); }
+  bulk_adapter rebind(bulk_t) const & { return *this; }
+  bulk_adapter rebind(bulk_t) && { return std::move(*this); }
+
+  template <class... T> auto rebind(T&&... t) const &
+    -> bulk_adapter<typename rebind_member_result<executor_type, T...>::type>
+      { return { always_blocking_single_ex_.rebind(std::forward<T>(t)...) }; }
+  template <class... T> auto rebind(T&&... t) &&
+    -> bulk_adapter<typename rebind_member_result<executor_type&&, T...>::type>
+      { return { std::move(always_blocking_single_ex_).rebind(std::forward<T>(t)...) }; }
+
+  auto& context() const noexcept { return always_blocking_single_ex_.context(); }
+
+  friend bool operator==(const bulk_adapter& a, const bulk_adapter& b) noexcept
+  {
+    return a.always_blocking_single_ex_ == b.always_blocking_single_ex_;
+  }
+
+  friend bool operator!=(const bulk_adapter& a, const bulk_adapter& b) noexcept
+  {
+    return !(a == b);
+  }
+
+  // two-way operator()
+  template <class Function, class ResultFactory, class SharedFactory>
+  future<typename std::result_of<ResultFactory()>::type> operator()(Function f, size_t n, ResultFactory rf, SharedFactory sf) const
+  {
+    using result_type = typename std::result_of<ResultFactory()>::type;
+
+    result_type result = rf();
+    auto shared = sf();
+
+    for(size_t i = 0; i < n; ++i)
+    {
+      always_blocking_single_ex_([=,&result,&shared]
+      {
+        f(i, result, shared);
+      });
+    }
+
+    return impl::make_always_ready_future<result_type>(std::move(result));
+  }
+
+  // one-way operator()
+  template <class Function, class SharedFactory>
+  void operator()(Function f, size_t n, SharedFactory sf) const
+  {
+    auto shared = sf();
+
+    for(size_t i = 0; i < n; ++i)
+    {
+      always_blocking_single_ex_([=,&shared]
+      {
+        f(i, shared);
+      });
+    }
+  }
+};
 
 // Default rebind for continuation mode does no adaptation.
 

--- a/rebind_prototype/include/experimental/execution
+++ b/rebind_prototype/include/experimental/execution
@@ -57,6 +57,17 @@ template<class Executor> struct executor_index;
 template<class Executor> using executor_shape_t = typename executor_shape<Executor>::type;
 template<class Executor> using executor_index_t = typename executor_index<Executor>::type;
 
+// Bulk forward progress.
+// XXX consider exposing these similar to the blocking guarantees et. al
+struct bulk_sequenced_execution {};
+struct bulk_parallel_execution {};
+struct bulk_unsequenced_execution {};
+
+// Type trait to obtain a bulk executor's bulk forward progress guarantee.
+template<class Executor> struct executor_bulk_forward_progress_guarantee;
+
+template<class Executor> using executor_bulk_forward_progress_guarantee_t = typename executor_bulk_forward_progress_guarantee<Executor>::type;
+
 // Type traits to determine whether a rebind member invocation is valid, and what its result is.
 template<class Executor, class... Args> struct has_rebind_member;
 template<class Executor, class... Args> struct rebind_member_result;
@@ -93,6 +104,7 @@ class one_way_executor;
 #include <experimental/bits/executor_future.h>
 #include <experimental/bits/executor_shape.h>
 #include <experimental/bits/executor_index.h>
+#include <experimental/bits/executor_bulk_forward_progress_guarantee.h>
 #include <experimental/bits/has_rebind_member.h>
 #include <experimental/bits/rebind_member_result.h>
 #include <experimental/bits/rebind_adaptations.h>


### PR DESCRIPTION
These changes introduce examples implementing std::invoke(executor, ...) & std::for_each(policy, ...).

Still a work in progress.