### PR TITLE
Issue #244: Finish wording and explanatory changes for query.

### DIFF
--- a/explanatory.md
+++ b/explanatory.md
@@ -1079,6 +1079,13 @@ Example using `std::status_value`:
       handle_error(sv);
     }
 
+The `execution::query` customization point can be used to retrieve the current
+value of standard properties, however it can also be used to retrieve the value
+of properties which represent executor capabilities or information. Some
+examples of these are the optimal shape for execution, memory affinity,
+execution priority, logging and tracing or task grouping. It's expected that an
+implementation will provide additional implementation specific properties.
+
 # Implementing Executors
 
 A programmer implements an executor by defining a type which satisfies the

--- a/explanatory.md
+++ b/explanatory.md
@@ -1020,6 +1020,65 @@ properties requested through a call to either `execution::require` or
 `execution::prefer` may be changed. The resulting executor must retain all the
 other properties of the original executor which were not named by the call.
 
+## Customization Points Query An Executor's Properties
+
+The current value of an executor's property can be queried through the
+`execution::query` customization point. This can be useful for querying whether
+a call to the `execution::prefer` was successful and the requested property is
+honoured by the returned executor but also as a general interface for querying
+information about an executor's capabilities.
+
+Whether a property can be queried can be known at compile-time using the
+`execution::can_query_v` type trait.
+
+The property value type which is returned can be known at compile-time using the
+`execution::property_value` type trait. This type will often be `bool` as
+querying a property will often return whether that property is enabled. However
+properties which require a value such as the `allocator` property are expected
+to return a container which can optionally store a value such as `std::optional`
+. If the implementation wishes to also have the option to return an error then
+it may choose to return `std::expected` (see P0323r2) or `std::status_value`
+(see P0262r1) in order to also provide an error or status in the case where the
+property could not be queried. The `execution::property_value` type is required
+to always be `DefaultConstructible` (C++Std [defaultconstructible]).
+
+Example using `std::optional`:
+
+    // get an executor through some means
+    my_executor_type my_executor = ...
+
+    std::optional<std::allocator<void>> opt = my_executor.query(allocator);
+
+    if (opt.has_value()) {
+      do_something_with(opt.value());
+    }
+
+Example using `std::expected`:
+
+    // get an executor through some means
+    my_executor_type my_executor = ...
+
+    std::expected<std::allocator<void>, property_error> exp = my_executor.query(allocator);
+
+    if (exp.has_value()) {
+      do_something_with(exp.value());
+    } else {
+      handle_error(exp.error());
+    }
+
+Example using `std::status_value`:
+
+    // get an executor through some means
+    my_executor_type my_executor = ...
+
+    std::status_value<property_query, std::allocator<void>> sv = my_executor.query(allocator);
+
+    if (sv.status() == property_query::success) {
+      do_something_with(sv.value());
+    } else {
+      handle_error(sv);
+    }
+
 # Implementing Executors
 
 A programmer implements an executor by defining a type which satisfies the

--- a/wording.md
+++ b/wording.md
@@ -39,7 +39,7 @@ namespace execution {
   constexpr struct caller_parallel_execution_t {} caller_parallel_execution;
   constexpr struct caller_concurrent_execution_t {} caller_concurrent_execution;
 
-  // Properties for bulk execution forward progress guarantees:
+  // Properties for bulk execution guarantees:
 
   constexpr struct bulk_sequenced_execution_t {} bulk_sequenced_execution;
   constexpr struct bulk_parallel_execution_t {} bulk_parallel_execution;
@@ -408,7 +408,7 @@ The `caller_weakly_parallel_execution`, `caller_parallel_execution`, and `caller
 
 [*Note:* The guarantees of `caller_weakly_parallel_execution`, `caller_parallel_execution` and `caller_concurrent_execution` implies the relationship: `caller_weakly_parallel_execution < caller_parallel_execution < caller_concurrent_execution` *--end note*]
 
-### Properties for bulk execution forward progress guarantees
+### Properties for bulk execution guarantees
 
 These properties communicate the forward progress and ordering guarantees of execution agents with respect to other agents within the same bulk submission.
 
@@ -554,8 +554,8 @@ This sub-clause contains templates that may be used to query the properties of a
 
 | Template                   | Condition           | Preconditions  |
 |----------------------------|---------------------|----------------|
-| `template<class T>` <br/>`struct has_require_member` | The expression `declval<const Executor>().require( declval<Property>())` is well formed. | `T` is a complete type. |
-| `template<class T>` <br/>`struct has_query_member` | The expression `declval<const Executor>().query( declval<Property>())` is well formed. | `T` is a complete type. |
+| `template<class Executor, class Property>` <br/>`struct has_require_member` | The expression `declval<const Executor>().require( declval<Property>())` is well formed. | `Executor` is a complete type. |
+| `template<class Executor, class Property>` <br/>`struct has_query_member` | The expression `declval<const Executor>().query( declval<Property>())` is well formed. | `Executor` is a complete type. |
 
 ### Member return type traits for properties
 
@@ -566,8 +566,8 @@ This sub-clause contains templates that may be used to query the properties of a
 
 | Template                   | Condition           | Comments  |
 |----------------------------|---------------------|-----------|
-| `template<class T>` <br/>`struct require_member_result` | The expression `declval<const Executor>().require( declval<Property>())` is well formed. | The member typedef `type` shall name the type of the expression `declval<const Executor>().require( declval<Property())`. |
-| `template<class T>` <br/>`struct query_member_result` | The expression `declval<const Executor>().query( declval<Property>())` is well formed. | The member typedef `type` shall name the type of the expression `declval<const Executor>().query( declval<Property())`. |
+| `template<class Executor, class Property>` <br/>`struct require_member_result` | The expression `declval<const Executor>().require( declval<Property>())` is well formed. | The member typedef `type` shall name the type of the expression `declval<const Executor>().require( declval<Property())`. |
+| `template<class Executor, class Property>` <br/>`struct query_member_result` | The expression `declval<const Executor>().query( declval<Property>())` is well formed. | The member typedef `type` shall name the type of the expression `declval<const Executor>().query( declval<Property())`. |
 
 ## Property value types traits for properties
 
@@ -575,7 +575,7 @@ This sub-clause contains templates that may be used to query the properties of a
 
 | Template                   | Condition           | Comments  |
 |----------------------------|---------------------|-----------|
-| `template<class T>` <br/>`struct property_value` | The expression `std::experimental::concurrency_v2::execution::query(declval<const Executor>(), declval<Property>())` is well formed. | The member typedef `type` shall name the type of the expression `std::experimental::concurrency_v2::execution::query(declval<const Executor>(), declval<Property())` and must satisfy `DefaultConstructible` (C++Std [defaultconstructible]) . |
+| `template<class Executor, class Property>` <br/>`struct property_value` | | The member typedef `type` shall name the type of the value associated with the property `Property`. |
 
 ## Executor customization points
 
@@ -651,15 +651,11 @@ When the executor customization point named `prefer` invokes a free execution fu
 
 The name `query` denotes a customization point. The effect of the expression `std::experimental::concurrency_v2::execution::query(E, P)` for some expressions `E` and `P` is equivalent to:
 
-* `(E).query(P)` if `property_value<decltype(E)>, decltype(P)>` satisfies `DefaultConstructible` (C++Std [defaultconstructible]) and `has_query_member_v<decay_t<decltype(E)>, decltype(P)>` is true.
+* `(E).query(P)` if `has_query_member_v<decay_t<decltype(E)>, decltype(P)>` is true.
 
-* Otherwise, `query(E, P)` if `property_value<decltype(E)>, decltype(P)>` satisfies `DefaultConstructible` (C++Std [defaultconstructible]) and the expression is well formed.
+* Otherwise, `query(E, P)` if the expression is well formed.
 
-* Otherwise, `property_value<decltype(E)>, decltype(P)>{}` if `property_value<decltype(E)>, decltype(P)>` satisfies `DefaultConstructible` (C++Std [defaultconstructible]).
-
-* Otherwise, `std::experimental::concurrency_v2::execution::prefer(E, P)` is ill-formed.
-
-[*Note:* `property_value<decltype(E)>, decltype(P)>` is required to be default constructible in order for the customisation point to be well-formed in the case where the property is either not supported by the executor or the executor fails to query the property. It is expected that `property_value<decltype(E)>, decltype(P)>` be a container type which can optionally store the value such as `std::optional` or potentially `std::expected` (see P0323r2) or `std::status_value` (see P0262r1) in order to also provide an error or status in the case where the property could not be queried. ]
+* Otherwise, `std::experimental::concurrency_v2::execution::query(E, P)` is ill-formed.
 
 ### Customization point type traits
 
@@ -741,26 +737,6 @@ public:
   executor require(never_blocking_t p) const;
   executor require(possibly_blocking_t p) const;
   executor require(always_blocking_t p) const;
-
-  query_member_result_t<executor, oneway_t> query(oneway_t) const;
-  query_member_result_t<executor, twoway_t> query(twoway_t) is_twoway_t;
-  query_member_result_t<executor, then_t> query(then_t) const;
-  query_member_result_t<executor, single_t> query(single_t) const;
-  query_member_result_t<executor, bulk_t> query(bulk_t) const;
-  query_member_result_t<executor, possibly_blocking_t> query(possibly_blocking_t) const;
-  query_member_result_t<executor, always_blocking_t> query(always_blocking_t) const;
-  query_member_result_t<executor, never_blocking_t> query(never_blocking_t) const;
-  query_member_result_t<executor, continuation_t> query(continuation_t) const;
-  query_member_result_t<executor, not_continuation_t> query(not_continuation_t) const;
-  query_member_result_t<executor, outstanding_work_t> query(outstanding_work_t) const;
-  query_member_result_t<executor, not_outstanding_work_t> query(not_outstanding_work_t) const;
-  query_member_result_t<executor, bulk_sequenced_execution_t> query(bulk_sequenced_execution_t) const;
-  query_member_result_t<executor, bulk_parallel_execution_t> query(bulk_parallel_execution_t) const;
-  query_member_result_t<executor, bulk_unsequenced_execution_t> query(bulk_unsequenced_execution_t) const;
-  query_member_result_t<executor, bulk_unsequenced_execution_t> query(bulk_unsequenced_execution_t) const;
-  query_member_result_t<executor, thread_execution_mapping_t> query(thread_execution_mapping_t) const;
-  query_member_result_t<executor, new_thread_execution_mapping_t> query(new_thread_execution_mapping_t) const;
-  query_member_result_t<executor, allocator_t> query(allocator_t) const;
 
   template<class Function>
     void execute(Function&& f) const;
@@ -867,24 +843,6 @@ template<class Executor> executor(Executor e);
   * `can_prefer_v<Executor, bulk_unsequenced_execution>`
   * `can_prefer_v<Executor, thread_execution_mapping>`
   * `can_prefer_v<Executor, new_thread_execution_mapping>`
-  * `can_query_v<Executor, oneway>`
-  * `can_query_v<Executor, twoway>`
-  * `can_query_v<Executor, then>`
-  * `can_query_v<Executor, single>`
-  * `can_query_v<Executor, bulk>`
-  * `can_query_v<Executor, never_blocking>`
-  * `can_query_v<Executor, possibly_blocking>`
-  * `can_query_v<Executor, always_blocking>`
-  * `can_query_v<Executor, continuation>`
-  * `can_query_v<Executor, not_continuation>`
-  * `can_query_v<Executor, outstanding_work>`
-  * `can_query_v<Executor, not_outstanding_work>`
-  * `can_query_v<Executor, bulk_sequenced_execution>`
-  * `can_query_v<Executor, bulk_parallel_execution>`
-  * `can_query_v<Executor, bulk_unsequenced_execution>`
-  * `can_query_v<Executor, thread_execution_mapping>`
-  * `can_query_v<Executor, new_thread_execution_mapping>`
-  * `can_query_v<Executor, allocator>`
 
 *Effects:* `*this` targets a copy of `e` initialized with `std::move(e)`.
 


### PR DESCRIPTION
**Changes to wording**

* Add property_value type trait for quering the type of a properties value.
* Improve the wording for the query customization point to include requirements for default constructible and case where query is not supported.
* Add the requirement to `property_value` that it must be default constructible.
* Add a note about the intended return types for the query customization point.

**Changes to explanatory**

* Add section describing the query customization point.
* Add examples of using `std::optional`, `std::expected` and `std::status_value`.